### PR TITLE
Chore/unit test setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,6 @@ jobs:
       - name: Generate Coverage Report
         run: ./gradlew jacocoTestReport
 
-      # Enforce code coverage
-      - name: Enforce code coverage
-        run: ./gradlew checkCoverage
-
       # Upload coverage report (optional if needed in a different job or for tracking)
       - name: Upload coverage
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,10 @@ jobs:
       - name: Generate Coverage Report
         run: ./gradlew jacocoTestReport
 
+      # Enforce code coverage
+      - name: Enforce code coverage
+        run: ./gradlew checkCoverage
+
       # Upload coverage report (optional if needed in a different job or for tracking)
       - name: Upload coverage
         uses: actions/upload-artifact@v4

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -206,12 +206,17 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
 fun parseCoverageRatio(file: File): Double {
     val xml = file.readText()
     println("Coverage XML Content: $xml")
-    val regex = Regex("""<counter type="INSTRUCTION" missed="(\d+)" covered="(\d+)" />""")
-    val match = regex.find(xml)
-    return if (match != null) {
-        val (missed, covered) = match.destructured
-        val total = missed.toDouble() + covered.toDouble()
-        covered.toDouble() / total
+    val regex = Regex("""<counter type="INSTRUCTION" missed="(\d+)" covered="(\d+)"\/>""")
+    val matches = regex.findAll(xml)
+    var missed = 0
+    var covered = 0
+    for (match in matches) {
+        val (missedCount, coveredCount) = match.destructured
+        missed += missedCount.toInt()
+        covered += coveredCount.toInt()
+    }
+    return if (missed + covered > 0) {
+        covered.toDouble() / (missed + covered)
     } else {
         -1.0
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -196,7 +196,7 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
         val coverageFile = file("${buildDir}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml")
         if (coverageFile.exists()) {
             val coverageRatio = parseCoverageRatio(coverageFile)
-            if (coverageRatio < 0.1) { // Set your desired coverage percentage here
+            if (coverageRatio <= 0) { // Set your desired coverage percentage here
                 throw GradleException("Code coverage is below 10%($coverageRatio)")
             }
         }
@@ -212,6 +212,6 @@ fun parseCoverageRatio(file: File): Double {
         val total = missed.toDouble() + covered.toDouble()
         covered.toDouble() / total
     } else {
-        0.0
+        -1.0
     }
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -161,8 +161,8 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
     mustRunAfter("testDebugUnitTest", "connectedDebugAndroidTest")
 
     reports {
-        xml.required = true
-        html.required = true
+        xml.required.set(true)
+        html.required.set(true)
     }
 
     val fileFilter = listOf(
@@ -186,20 +186,18 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
         include("outputs/code_coverage/debugAndroidTest/connected/*/coverage.ec")
     })
 
-    afterEvaluate {
-        classDirectories.setFrom(files(classDirectories.files.map {
-            fileTree(it) {
-                exclude(fileFilter)
-            }
-        }))
-    }
+    classDirectories.setFrom(files(classDirectories.files.map {
+        fileTree(it) {
+            exclude(fileFilter)
+        }
+    }))
 
     doLast {
         val coverageFile = file("${buildDir}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml")
         if (coverageFile.exists()) {
             val coverageRatio = parseCoverageRatio(coverageFile)
-            if (coverageRatio < 0.1) { // Set your desired coverage percentage here
-                throw GradleException("Code coverage is below 10%")
+            if (coverageRatio < 0.8) { // Set your desired coverage percentage here
+                throw GradleException("Code coverage is below 80%")
             }
         }
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,6 +7,10 @@ plugins {
     id("jacoco")
 }
 
+jacoco {
+    toolVersion = "0.8.8"
+}
+
 android {
     namespace = "com.android.sample"
     compileSdk = 34
@@ -73,10 +77,6 @@ android {
         }
     }
 
-    // Robolectric needs to be run only in debug. But its tests are placed in the shared source set (test)
-    // The next lines transfers the src/test/* from shared to the testDebug one
-    //
-    // This prevent errors from occurring during unit tests
     sourceSets.getByName("testDebug") {
         val test = sourceSets.getByName("test")
 
@@ -98,16 +98,12 @@ sonar {
         property("sonar.projectName", "Android-Sample")
         property("sonar.organization", "gabrielfleischer")
         property("sonar.host.url", "https://sonarcloud.io")
-        // Comma-separated paths to the various directories containing the *.xml JUnit report files. Each path may be absolute or relative to the project base directory.
         property("sonar.junit.reportPaths", "${project.layout.buildDirectory.get()}/test-results/testDebugunitTest/")
-        // Paths to xml files with Android Lint issues. If the main flavor is changed, this file will have to be changed too.
         property("sonar.androidLint.reportPaths", "${project.layout.buildDirectory.get()}/reports/lint-results-debug.xml")
-        // Paths to JaCoCo XML coverage report files.
         property("sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory.get()}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml")
     }
 }
 
-// When a library is used both by robolectric and connected tests, use this function
 fun DependencyHandlerScope.globalTestImplementation(dep: Any) {
     androidTestImplementation(dep)
     testImplementation(dep)
@@ -123,40 +119,30 @@ dependencies {
     globalTestImplementation(libs.androidx.junit)
     globalTestImplementation(libs.androidx.espresso.core)
 
-    // ------------- Jetpack Compose ------------------
     val composeBom = platform(libs.compose.bom)
     implementation(composeBom)
     globalTestImplementation(composeBom)
 
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.graphics)
-    // Material Design 3
     implementation(libs.compose.material3)
-    // Integration with activities
     implementation(libs.compose.activity)
-    // Integration with ViewModels
     implementation(libs.compose.viewmodel)
-    // Android Studio Preview support
     implementation(libs.compose.preview)
     debugImplementation(libs.compose.tooling)
-    // UI Tests
     globalTestImplementation(libs.compose.test.junit)
     debugImplementation(libs.compose.test.manifest)
 
-    // --------- Kaspresso test framework ----------
     globalTestImplementation(libs.kaspresso)
     globalTestImplementation(libs.kaspresso.compose)
 
-    // ----------       Robolectric     ------------
     testImplementation(libs.robolectric)
 
-    // Google Service and Maps
     implementation(libs.play.services.maps)
     implementation(libs.maps.compose)
     implementation(libs.maps.compose.utils)
     implementation(libs.play.services.auth)
 
-    // Firebase
     implementation(libs.firebase.database.ktx)
     implementation(libs.firebase.firestore)
     implementation(libs.firebase.ui.auth)
@@ -165,7 +151,6 @@ dependencies {
 }
 
 tasks.withType<Test> {
-    // Configure Jacoco for each tests
     configure<JacocoTaskExtension> {
         isIncludeNoLocationClasses = true
         excludes = listOf("jdk.internal.*")
@@ -200,4 +185,35 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
         include("outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec")
         include("outputs/code_coverage/debugAndroidTest/connected/*/coverage.ec")
     })
+
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.map {
+            fileTree(it) {
+                exclude(fileFilter)
+            }
+        }))
+    }
+
+    doLast {
+        val coverageFile = file("${buildDir}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml")
+        if (coverageFile.exists()) {
+            val coverageRatio = parseCoverageRatio(coverageFile)
+            if (coverageRatio < 0.8) { // Set your desired coverage percentage here
+                throw GradleException("Code coverage is below 80%")
+            }
+        }
+    }
+}
+
+fun parseCoverageRatio(file: File): Double {
+    val xml = file.readText()
+    val regex = Regex("""<counter type="INSTRUCTION" missed="(\d+)" covered="(\d+)" />""")
+    val match = regex.find(xml)
+    return if (match != null) {
+        val (missed, covered) = match.destructured
+        val total = missed.toDouble() + covered.toDouble()
+        covered.toDouble() / total
+    } else {
+        0.0
+    }
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -205,6 +205,7 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
 
 fun parseCoverageRatio(file: File): Double {
     val xml = file.readText()
+    println("Coverage XML Content: $xml")
     val regex = Regex("""<counter type="INSTRUCTION" missed="(\d+)" covered="(\d+)" />""")
     val match = regex.find(xml)
     return if (match != null) {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -198,8 +198,8 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
         val coverageFile = file("${buildDir}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml")
         if (coverageFile.exists()) {
             val coverageRatio = parseCoverageRatio(coverageFile)
-            if (coverageRatio < 0.8) { // Set your desired coverage percentage here
-                throw GradleException("Code coverage is below 80%")
+            if (coverageRatio < 0.1) { // Set your desired coverage percentage here
+                throw GradleException("Code coverage is below 10%")
             }
         }
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -196,8 +196,8 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
         val coverageFile = file("${buildDir}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml")
         if (coverageFile.exists()) {
             val coverageRatio = parseCoverageRatio(coverageFile)
-            if (coverageRatio < 0.8) { // Set your desired coverage percentage here
-                throw GradleException("Code coverage is below 80%")
+            if (coverageRatio < 0.1) { // Set your desired coverage percentage here
+                throw GradleException("Code coverage is below 10%($coverageRatio)")
             }
         }
     }


### PR DESCRIPTION
## Description

- **What has been changed?**  
  This PR introduces a mechanism to track and enforce code coverage during CI runs using the JaCoCo plugin. The goal is to ensure that a certain percentage of the code is covered by unit tests. Currently, this threshold is set to 0%, but this will be increased in the future as more tests are added.

  Specifically, the following changes were made:
  - The `jacocoTestReport` task was modified to exclude specific directories from the coverage calculation using the `classDirectories.setFrom` method.
  - A post-test coverage validation step was added, which parses the JaCoCo XML report to calculate the percentage of instructions covered by tests.
  - If the coverage percentage falls below the set threshold (currently 0%), the build fails with a descriptive error message.
  
  Code added:
  ```kotlin
  classDirectories.setFrom(files(classDirectories.files.map {
      fileTree(it) {
          exclude(fileFilter)
      }
  }))

  doLast {
      val coverageFile = file("${buildDir}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml")
      if (coverageFile.exists()) {
          val coverageRatio = parseCoverageRatio(coverageFile)
          if (coverageRatio <= 0) { // Set your desired coverage percentage here
              throw GradleException("Code coverage is below 10%($coverageRatio)")
          }
      }
  }
  ```

  Additionally, a helper function `parseCoverageRatio` was introduced to extract the coverage ratio from the JaCoCo XML report. This function calculates the percentage of instructions covered by tests by parsing the XML data, counting missed and covered instructions:
  ```kotlin
  fun parseCoverageRatio(file: File): Double {
      val xml = file.readText()
      val regex = Regex("""<counter type="INSTRUCTION" missed="(\d+)" covered="(\d+)"\/>""")
      val matches = regex.findAll(xml)
      var missed = 0
      var covered = 0
      for (match in matches) {
          val (missedCount, coveredCount) = match.destructured
          missed += missedCount.toInt()
          covered += coveredCount.toInt()
      }
      return if (missed + covered > 0) {
          covered.toDouble() / (missed + covered)
      } else {
          -1.0
      }
  }
  ```

- **Why was this change made?**  
  This change was made to ensure that as the codebase grows, we can start enforcing a minimum level of test coverage for new code. The current threshold is set to 0% to allow the team to progressively increase the coverage requirement over time without disrupting the build pipeline immediately. This setup will encourage developers to write tests and improve overall code quality.

## Checklist
- [x] Tests added.  
  No additional tests were required for this CI change, but unit tests should be written to meet future coverage thresholds.
- [ ] Documentation updated.  
  Documentation will be updated as the coverage threshold increases.
- [x] All CI checks passed.  
  All checks related to code coverage and CI pipelines are currently passing with the initial setup.
- [ ] Linked issue/feature (if applicable):  
  None linked.
