### PR TITLE
Chore/mock dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -148,6 +148,24 @@ dependencies {
     implementation(libs.firebase.ui.auth)
     implementation(libs.firebase.auth.ktx)
     implementation(libs.firebase.auth)
+
+    implementation(libs.androidx.fragment.ktx)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.okhttp)
+    androidTestImplementation(libs.mockk)
+    androidTestImplementation(libs.mockk.android)
+    androidTestImplementation(libs.mockk.agent)
+    testImplementation(libs.json)
+    androidTestImplementation(libs.androidx.espresso.intents)
+    androidTestImplementation(libs.androidx.ui.test.junit4)
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito.inline)
+    testImplementation(libs.mockito.kotlin)
+    androidTestImplementation(libs.mockito.android)
+    androidTestImplementation(libs.mockito.kotlin)
+    androidTestImplementation(libs.kaspresso.allure.support)
+    androidTestImplementation(libs.kaspresso.compose.support)
+    testImplementation(libs.kotlinx.coroutines.test)
 }
 
 tasks.withType<Test> {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,15 +47,6 @@ android {
         jacocoVersion = "0.8.8"
     }
 
-    buildFeatures {
-        compose = true
-    }
-
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.1"
-    }
-
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,6 +51,7 @@ android {
         compose = true
     }
 
+
     composeOptions {
         kotlinCompilerExtensionVersion = "1.4.2"
     }
@@ -63,10 +64,24 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+    buildFeatures {
+        compose = true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.1"
+    }
 
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
+            merges += "META-INF/LICENSE.md"
+            merges += "META-INF/LICENSE-notice.md"
+            excludes += "META-INF/LICENSE-notice.md"
+            excludes += "META-INF/LICENSE.md"
+            excludes += "META-INF/LICENSE"
+            excludes += "META-INF/LICENSE.txt"
+            excludes += "META-INF/NOTICE"
+            excludes += "META-INF/NOTICE.txt"
         }
     }
 
@@ -75,6 +90,20 @@ android {
             isIncludeAndroidResources = true
             isReturnDefaultValues = true
         }
+        packagingOptions {
+            jniLibs {
+                useLegacyPackaging = true
+            }
+        }
+    }
+
+    buildFeatures {
+        compose = true
+        buildConfig = true
+    }
+
+    kotlinOptions {
+        jvmTarget = "11"
     }
 
     sourceSets.getByName("testDebug") {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,16 +53,16 @@ android {
 
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.2"
+        kotlinCompilerExtensionVersion = "1.5.1"
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
     buildFeatures {
         compose = true

--- a/app/src/main/java/com/android/sample/MyService.kt
+++ b/app/src/main/java/com/android/sample/MyService.kt
@@ -1,0 +1,7 @@
+package com.android.sample
+
+class MyService {
+    fun performAction(): String {
+        return "Action Performed"
+    }
+}

--- a/app/src/main/java/com/android/sample/MyService.kt
+++ b/app/src/main/java/com/android/sample/MyService.kt
@@ -1,7 +1,7 @@
 package com.android.sample
 
 class MyService {
-    fun performAction(): String {
-        return "Action Performed"
-    }
+  fun performAction(): String {
+    return "Action Performed"
+  }
 }

--- a/app/src/test/java/com/android/sample/MyServiceTest.kt
+++ b/app/src/test/java/com/android/sample/MyServiceTest.kt
@@ -1,0 +1,30 @@
+package com.android.sample
+
+import org.junit.Test
+import org.mockito.Mockito.*
+import org.mockito.MockitoAnnotations
+import org.junit.Before
+
+class MyServiceTest {
+
+    private lateinit var myService: MyService
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        myService = mock(MyService::class.java)
+    }
+
+    @Test
+    fun testPerformAction() {
+        // Arrange
+        `when`(myService.performAction()).thenReturn("Mocked Action")
+
+        // Act
+        val result = myService.performAction()
+
+        // Assert
+        assert(result == "Mocked Action")
+        verify(myService).performAction()
+    }
+}

--- a/app/src/test/java/com/android/sample/MyServiceTest.kt
+++ b/app/src/test/java/com/android/sample/MyServiceTest.kt
@@ -1,30 +1,30 @@
 package com.android.sample
 
+import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.*
 import org.mockito.MockitoAnnotations
-import org.junit.Before
 
 class MyServiceTest {
 
-    private lateinit var myService: MyService
+  private lateinit var myService: MyService
 
-    @Before
-    fun setUp() {
-        MockitoAnnotations.openMocks(this)
-        myService = mock(MyService::class.java)
-    }
+  @Before
+  fun setUp() {
+    MockitoAnnotations.openMocks(this)
+    myService = mock(MyService::class.java)
+  }
 
-    @Test
-    fun testPerformAction() {
-        // Arrange
-        `when`(myService.performAction()).thenReturn("Mocked Action")
+  @Test
+  fun testPerformAction() {
+    // Arrange
+    `when`(myService.performAction()).thenReturn("Mocked Action")
 
-        // Act
-        val result = myService.performAction()
+    // Act
+    val result = myService.performAction()
 
-        // Assert
-        assert(result == "Mocked Action")
-        verify(myService).performAction()
-    }
+    // Assert
+    assert(result == "Mocked Action")
+    verify(myService).performAction()
+  }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,21 +1,45 @@
 [versions]
+# Plugins
 agp = "8.3.0"
+json = "20240303"
 kotlin = "1.8.10"
-coreKtx = "1.12.0"
+gms = "4.4.2"
 ktfmt = "0.17.0"
-junit = "4.13.2"
-junitVersion = "1.1.5"
-espressoCore = "3.5.1"
-appcompat = "1.6.1"
-material = "1.11.0"
-composeBom = "2024.02.02"
+sonar = "4.4.1.3373"
+
+# IU Compose
 composeActivity = "1.8.2"
 composeViewModel = "2.7.0"
-lifecycleRuntimeKtx = "2.7.0"
+material = "1.11.0"
+composeBom = "2024.02.02"
+mockitoAndroid = "5.13.0"
+ui = "1.6.8"
+uiTestJunit4 = "1.6.8"
+uiTestManifest = "1.6.8"
+uiTooling = "1.6.8"
+constraintlayout = "2.1.4"
+material3 = "1.2.1"
+materialVersion = "1.12.0"
+
+
+# Testing unit
+junit = "4.13.2"
+mockitoCore = "3.12.4"
+mockitoInline = "3.12.4"
+mockitoKotlin = "5.4.0"
+mockk = "1.13.7"
+
+# Testing UI
+junitVersion = "1.1.5"
+espressoCore = "3.5.1"
 kaspresso = "1.5.5"
 robolectric = "4.11.1"
-sonar = "4.4.1.3373"
-gms = "4.4.2"
+kaspressoAllureSupport = "1.4.3"
+kaspressoComposeSupport = "1.5.5"
+mockkAgent = "1.13.7"
+mockkAndroid = "1.13.7"
+navigationCompose = "2.7.7"
+
 # Firebase
 firebaseAuth = "23.0.0"
 firebaseAuthKtx = "23.0.0"
@@ -28,6 +52,19 @@ playServicesAuth = "21.2.0"
 playServicesMaps = "19.0.0"
 mapsCompose = "4.3.3"
 mapsComposeUtils = "4.3.0"
+
+# AndroidX and Core lib
+lifecycleRuntimeKtx = "2.7.0"
+coreKtx = "1.12.0"
+fragmentKtx = "1.8.2"
+appcompat = "1.6.1"
+activityCompose = "1.9.1"
+coreKtxVersion = "1.8.1"
+kotlinxSerializationJson = "1.6.2"
+androidxCoreKtx = "1.6.1"
+
+# Networking
+okhttp = "4.12.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -54,15 +91,49 @@ kaspresso-compose = { group = "com.kaspersky.android-components", name = "kaspre
 
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
+# Firebase
 firebase-auth = { module = "com.google.firebase:firebase-auth", version.ref = "firebaseAuth" }
 firebase-auth-ktx = { module = "com.google.firebase:firebase-auth-ktx", version.ref = "firebaseAuthKtx" }
 firebase-database-ktx = { module = "com.google.firebase:firebase-database-ktx", version.ref = "firebaseDatabaseKtx" }
 firebase-firestore = { module = "com.google.firebase:firebase-firestore", version.ref = "firebaseFirestore" }
 firebase-ui-auth = { module = "com.firebaseui:firebase-ui-auth", version.ref = "firebaseUiAuth" }
+
+# Google service
 maps-compose = { module = "com.google.maps.android:maps-compose", version.ref = "mapsCompose" }
 maps-compose-utils = { module = "com.google.maps.android:maps-compose-utils", version.ref = "mapsComposeUtils" }
 play-services-auth = { module = "com.google.android.gms:play-services-auth", version.ref = "playServicesAuth" }
 play-services-maps = { module = "com.google.android.gms:play-services-maps", version.ref = "playServicesMaps" }
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
+androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
+androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
+androidx-espresso-intents = { module = "androidx.test.espresso:espresso-intents", version.ref = "espressoCore" }
+androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "fragmentKtx" }
+androidx-material = { module = "androidx.compose.material:material", version.ref = "material" }
+androidx-material3 = { module = "androidx.compose.material3:material3", version.ref = "material3" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
+androidx-navigation-fragment-ktx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "navigationCompose" }
+androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "navigationCompose" }
+androidx-ui = { module = "androidx.compose.ui:ui", version.ref = "ui" }
+androidx-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
+androidx-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "uiTestJunit4" }
+androidx-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "uiTestManifest" }
+androidx-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "uiTooling" }
+androidx-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "ui" }
+core-ktx = { module = "com.google.android.play:core-ktx", version.ref = "coreKtxVersion" }
+json = { module = "org.json:json", version.ref = "json" }
+kaspresso-allure-support = { module = "com.kaspersky.android-components:kaspresso-allure-support", version.ref = "kaspressoAllureSupport" }
+kaspresso-compose-support = { module = "com.kaspersky.android-components:kaspresso-compose-support", version.ref = "kaspressoComposeSupport" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+mockito-android = { module = "org.mockito:mockito-android", version.ref = "mockitoAndroid" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoCore" }
+mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockitoInline" }
+mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin" , version.ref="mockitoKotlin"}
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+mockk-agent = { module = "io.mockk:mockk-agent", version.ref = "mockkAgent" }
+mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockkAndroid" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+test-core-ktx = { group = "androidx.test", name = "core-ktx", version.ref = "androidxCoreKtx" }
 
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 # Plugins
-agp = "8.3.0"
+agp = "8.4.2"
 json = "20240303"
-kotlin = "1.8.10"
+kotlin = "1.9.0"
 gms = "4.4.2"
 ktfmt = "0.17.0"
 sonar = "4.4.1.3373"
@@ -54,10 +54,10 @@ mapsCompose = "4.3.3"
 mapsComposeUtils = "4.3.0"
 
 # AndroidX and Core lib
-lifecycleRuntimeKtx = "2.7.0"
-coreKtx = "1.12.0"
+lifecycleRuntimeKtx = "2.8.4"
+coreKtx = "1.13.1"
 fragmentKtx = "1.8.2"
-appcompat = "1.6.1"
+appcompat = "1.7.0"
 activityCompose = "1.9.1"
 coreKtxVersion = "1.8.1"
 kotlinxSerializationJson = "1.6.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Mar 11 13:43:48 CET 2024
+#Fri Oct 04 23:44:28 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
# PULL REQUEST: Add Mockito and OkHttp3 Dependencies with Sample Test

## Description
- Added **Mockito** dependency to the project to support unit testing.
- Created `MyServiceTest` as an example of using Mockito to mock and verify behavior.
- Added **OkHttp3** dependency for network operations.
- Included additional dependencies for **Jetpack Compose** and **fragments** to support UI and component development.
  
The following sample test is included in the `com.android.sample` package:

```kotlin
package com.android.sample

import org.junit.Test
import org.mockito.Mockito.*
import org.mockito.MockitoAnnotations
import org.junit.Before

class MyServiceTest {

    private lateinit var myService: MyService

    @Before
    fun setUp() {
        MockitoAnnotations.openMocks(this)
        myService = mock(MyService::class.java)
    }

    @Test
    fun testPerformAction() {
        // Arrange
        when(myService.performAction()).thenReturn("Mocked Action")

        // Act
        val result = myService.performAction()

        // Assert
        assert(result == "Mocked Action")
        verify(myService).performAction()
    }
}
```

## Why was this change made?
- The changes allow for effective unit testing with Mockito.
- Dependencies like OkHttp3, Compose, and fragments were added to facilitate network operations and UI components.

## Checklist
- [x] Tests added (`MyServiceTest` created to validate Mockito setup).
- [ ] Documentation updated (N/A).
- [x] All CI checks passed.
- [ ] Linked issue/feature (if applicable): #123