### PR TITLE
Add Tests for Recipe Creation and Enhance RecipesViewModel Testing

### DIFF
--- a/app/src/main/java/com/android/sample/model/recipe/Recipe.kt
+++ b/app/src/main/java/com/android/sample/model/recipe/Recipe.kt
@@ -19,4 +19,10 @@ data class Recipe(
     val strInstructions: String,
     val strMealThumbUrl: String,
     val ingredientsAndMeasurements: List<Pair<String, String>>
-)
+) {
+  init {
+    require(ingredientsAndMeasurements.isNotEmpty()) {
+      "Ingredients and measurements must not be empty"
+    }
+  }
+}

--- a/app/src/main/java/com/android/sample/model/recipe/RecipesViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/recipe/RecipesViewModel.kt
@@ -23,6 +23,11 @@ class RecipesViewModel(private val repository: RecipeRepository) : ViewModel() {
   val loading: StateFlow<Boolean>
     get() = _loading
 
+  // StateFlow for the current selected recipe
+  private val _currentRecipe = MutableStateFlow<Recipe?>(null)
+  val currentRecipe: StateFlow<Recipe?>
+    get() = _currentRecipe
+
   init {
     // Removed the fetchRandomRecipes() call from the init block for testing purposes
   }
@@ -33,6 +38,8 @@ class RecipesViewModel(private val repository: RecipeRepository) : ViewModel() {
    * @param numberOfRecipes The number of random recipes to fetch.
    */
   fun fetchRandomRecipes(numberOfRecipes: Int) {
+    require(numberOfRecipes >= 1) { "Number of fetched recipes must be at least 1" }
+
     _loading.value = true // Set loading to true while fetching
     repository.random(
         nbOfElements = numberOfRecipes,
@@ -44,5 +51,19 @@ class RecipesViewModel(private val repository: RecipeRepository) : ViewModel() {
           _loading.value = false // Set loading to false on failure
           // Handle error (e.g., log it or show a message)
         })
+  }
+
+  /**
+   * Updates the current selected recipe.
+   *
+   * @param recipe The recipe to set as the current recipe.
+   */
+  fun updateCurrentRecipe(recipe: Recipe) {
+    _currentRecipe.value = recipe
+  }
+
+  /** Clears the current selected recipe. */
+  fun clearCurrentRecipe() {
+    _currentRecipe.value = null
   }
 }

--- a/app/src/main/java/com/android/sample/model/recipe/RecipesViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/recipe/RecipesViewModel.kt
@@ -24,8 +24,7 @@ class RecipesViewModel(private val repository: RecipeRepository) : ViewModel() {
     get() = _loading
 
   init {
-    // Fetch a default number of random recipes when ViewModel is created
-    fetchRandomRecipes(5) // Fetch 5 random recipes as an example
+    // Removed the fetchRandomRecipes() call from the init block for testing purposes
   }
 
   /**

--- a/app/src/test/java/com/android/sample/model/recipe/RecipeTest.kt
+++ b/app/src/test/java/com/android/sample/model/recipe/RecipeTest.kt
@@ -3,6 +3,7 @@ package com.android.sample.model.recipe
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Assert.assertThrows
 import org.junit.Test
 
 class RecipeTest {
@@ -68,5 +69,28 @@ class RecipeTest {
     assertThat(recipe.strInstructions, `is`(strInstructions))
     assertThat(recipe.strMealThumbUrl, `is`(strMealThumbUrl))
     assertThat(recipe.ingredientsAndMeasurements, `is`(ingredientsAndMeasurements))
+  }
+
+  @Test
+  fun `create Recipe with empty ingredientsAndMeasurements list`() {
+    // Arrange
+    val idMeal = "3"
+    val strMeal = "Empty Ingredients Test"
+    val strInstructions = "Instructions here..."
+    val strMealThumbUrl = "https://example.com/empty-ingredients-test"
+
+    // Act & Assert
+    val exception =
+        assertThrows(IllegalArgumentException::class.java) {
+          Recipe(
+              idMeal = idMeal,
+              strMeal = strMeal,
+              strCategory = null,
+              strArea = null,
+              strInstructions = strInstructions,
+              strMealThumbUrl = strMealThumbUrl,
+              ingredientsAndMeasurements = emptyList())
+        }
+    assertThat(exception.message, `is`("Ingredients and measurements must not be empty"))
   }
 }

--- a/app/src/test/java/com/android/sample/model/recipe/RecipeTest.kt
+++ b/app/src/test/java/com/android/sample/model/recipe/RecipeTest.kt
@@ -1,0 +1,72 @@
+package com.android.sample.model.recipe
+
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.CoreMatchers.nullValue
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+
+class RecipeTest {
+
+  @Test
+  fun `create Recipe with valid data`() {
+    // Arrange
+    val idMeal = "1"
+    val strMeal = "Spicy Arrabiata Penne"
+    val strCategory = "Vegetarian"
+    val strArea = "Italian"
+    val strInstructions = "Instructions here..."
+    val strMealThumbUrl = "https://www.recipetineats.com/penne-all-arrabbiata-spicy-tomato-pasta/"
+    val ingredientsAndMeasurements = listOf(Pair("Penne", "1 pound"), Pair("Olive oil", "1/4 cup"))
+
+    // Act
+    val recipe =
+        Recipe(
+            idMeal = idMeal,
+            strMeal = strMeal,
+            strCategory = strCategory,
+            strArea = strArea,
+            strInstructions = strInstructions,
+            strMealThumbUrl = strMealThumbUrl,
+            ingredientsAndMeasurements = ingredientsAndMeasurements)
+
+    // Assert
+    assertThat(recipe.idMeal, `is`(idMeal))
+    assertThat(recipe.strMeal, `is`(strMeal))
+    assertThat(recipe.strCategory, `is`(strCategory))
+    assertThat(recipe.strArea, `is`(strArea))
+    assertThat(recipe.strInstructions, `is`(strInstructions))
+    assertThat(recipe.strMealThumbUrl, `is`(strMealThumbUrl))
+    assertThat(recipe.ingredientsAndMeasurements, `is`(ingredientsAndMeasurements))
+  }
+
+  @Test
+  fun `create Recipe with nullable properties`() {
+    // Arrange
+    val idMeal = "2"
+    val strMeal = "Chicken Curry"
+    val strInstructions = "Instructions here..."
+    val strMealThumbUrl = "https://www.foodfashionparty.com/2023/08/05/everyday-chicken-curry/"
+    val ingredientsAndMeasurements =
+        listOf(Pair("Chicken", "1 pound"), Pair("Curry powder", "2 tbsp"))
+
+    // Act
+    val recipe =
+        Recipe(
+            idMeal = idMeal,
+            strMeal = strMeal,
+            strCategory = null, // Nullable
+            strArea = null, // Nullable
+            strInstructions = strInstructions,
+            strMealThumbUrl = strMealThumbUrl,
+            ingredientsAndMeasurements = ingredientsAndMeasurements)
+
+    // Assert
+    assertThat(recipe.idMeal, `is`(idMeal))
+    assertThat(recipe.strMeal, `is`(strMeal))
+    assertThat(recipe.strCategory, `is`(nullValue())) // Use nullValue() matcher
+    assertThat(recipe.strArea, `is`(nullValue())) // Use nullValue() matcher
+    assertThat(recipe.strInstructions, `is`(strInstructions))
+    assertThat(recipe.strMealThumbUrl, `is`(strMealThumbUrl))
+    assertThat(recipe.ingredientsAndMeasurements, `is`(ingredientsAndMeasurements))
+  }
+}

--- a/app/src/test/java/com/android/sample/model/recipe/RecipesViewModelTest.kt
+++ b/app/src/test/java/com/android/sample/model/recipe/RecipesViewModelTest.kt
@@ -21,7 +21,7 @@ class RecipesViewModelTest {
   private val dummyRecipes: List<Recipe> =
       listOf(
           Recipe(
-              idMeal = "1", // Updated to String
+              idMeal = "1",
               strMeal = "Spicy Arrabiata Penne",
               strCategory = "Vegetarian",
               strArea = "Italian",
@@ -31,7 +31,7 @@ class RecipesViewModelTest {
               ingredientsAndMeasurements =
                   listOf(Pair("Penne", "1 pound"), Pair("Olive oil", "1/4 cup"))),
           Recipe(
-              idMeal = "2", // Updated to String
+              idMeal = "2",
               strMeal = "Chicken Curry",
               strCategory = "Non-Vegetarian",
               strArea = "Indian",
@@ -39,9 +39,7 @@ class RecipesViewModelTest {
               strMealThumbUrl =
                   "https://www.foodfashionparty.com/2023/08/05/everyday-chicken-curry/",
               ingredientsAndMeasurements =
-                  listOf(Pair("Chicken", "1 pound"), Pair("Curry powder", "2 tbsp")))
-          // Add more dummy recipes as needed
-          )
+                  listOf(Pair("Chicken", "1 pound"), Pair("Curry powder", "2 tbsp"))))
 
   @Before
   fun setUp() {
@@ -49,6 +47,13 @@ class RecipesViewModelTest {
     recipeRepository = mock(RecipeRepository::class.java)
     // Initialize the RecipesViewModel with the mocked repository
     recipesViewModel = RecipesViewModel(recipeRepository)
+  }
+
+  @Test
+  fun initialStateIsCorrect() {
+    // Assert initial state is correct
+    assertThat(recipesViewModel.recipes.value, `is`(emptyList<Recipe>()))
+    assertThat(recipesViewModel.loading.value, `is`(false))
   }
 
   @Test
@@ -66,6 +71,7 @@ class RecipesViewModelTest {
     assertThat(
         recipesViewModel.recipes.value,
         `is`(dummyRecipes)) // Check if the ViewModel's recipes are updated
+    assertThat(recipesViewModel.loading.value, `is`(false)) // Check loading is false after fetching
   }
 
   @Test
@@ -82,5 +88,23 @@ class RecipesViewModelTest {
             eq(numberOfRecipes),
             any(),
             any()) // Verify that the repository's random method is called
+  }
+
+  @Test
+  fun fetchRandomRecipesHandlesFailure() {
+    // Simulate the failure of the repository
+    `when`(recipeRepository.random(any(), any(), any())).thenAnswer { invocation ->
+      val onFailure = invocation.arguments[2] as (Exception) -> Unit
+      onFailure(Exception("Network error")) // Simulate a failure
+    }
+
+    // Act
+    recipesViewModel.fetchRandomRecipes(2)
+
+    // Assert
+    assertThat(recipesViewModel.loading.value, `is`(false)) // Check loading is false after fetch
+    assertThat(
+        recipesViewModel.recipes.value,
+        `is`(emptyList<Recipe>())) // Ensure no recipes are set on failure
   }
 }

--- a/app/src/test/java/com/android/sample/model/recipe/RecipesViewModelTest.kt
+++ b/app/src/test/java/com/android/sample/model/recipe/RecipesViewModelTest.kt
@@ -3,7 +3,9 @@ package com.github.se.bootcamp.model.recipe
 import com.android.sample.model.recipe.Recipe
 import com.android.sample.model.recipe.RecipeRepository
 import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentMatchers.eq
@@ -106,5 +108,43 @@ class RecipesViewModelTest {
     assertThat(
         recipesViewModel.recipes.value,
         `is`(emptyList<Recipe>())) // Ensure no recipes are set on failure
+  }
+
+  @Test
+  fun fetchRandomRecipesThrowsExceptionForInvalidNumber() {
+    // Arrange
+    val invalidNumberOfRecipes = 0
+
+    // Act & Assert
+    val exception =
+        assertThrows(IllegalArgumentException::class.java) {
+          recipesViewModel.fetchRandomRecipes(invalidNumberOfRecipes)
+        }
+    assertThat(exception.message, `is`("Number of fetched recipes must be at least 1"))
+  }
+
+  @Test
+  fun updateCurrentRecipeUpdatesState() {
+    // Arrange
+    val recipe = dummyRecipes[0]
+
+    // Act
+    recipesViewModel.updateCurrentRecipe(recipe)
+
+    // Assert
+    assertThat(recipesViewModel.currentRecipe.value, `is`(recipe))
+  }
+
+  @Test
+  fun clearCurrentRecipeClearsState() {
+    // Arrange
+    val recipe = dummyRecipes[0]
+    recipesViewModel.updateCurrentRecipe(recipe)
+
+    // Act
+    recipesViewModel.clearCurrentRecipe()
+
+    // Assert
+    assertThat(recipesViewModel.currentRecipe.value, `is`(nullValue()))
   }
 }


### PR DESCRIPTION
## Description
- **What has been changed?**
  - Enhanced the `RecipesViewModel` tests by adding assertions to check the loading state and ensuring that no recipes are set on failure.
  - Added unit tests for the creation of `Recipe` instances with both valid and nullable properties.
  - Refactored the `RecipesViewModel` to remove the initial fetch of random recipes in the `init` block, facilitating easier testing.
  ```kotlin
  init {
    // Removed the fetchRandomRecipes() call from the init block for testing purposes
  }
  ```
Please do not hesitate to make any suggestions for the init block if you have any.

- **Why was this change made?**
  These changes were made to improve the test coverage and reliability of the `RecipesViewModel` by ensuring that the loading state is properly managed and that the ViewModel starts with an empty state. This refactor also makes the ViewModel easier to test by removing side effects from the initialization process.

## Checklist

- [x] **Tests added**:
  - `create Recipe with nullable properties` (in `RecipeTest.kt`): This test ensures that `Recipe` instances can be created with nullable properties, verifying the class's behavior with optional fields.
  - `fetchRandomRecipesHandlesFailure` (in `RecipesViewModelTest.kt`): This test simulates a failure in fetching random recipes and checks that the loading state is set to false and no recipes are set.
  - `initialStateIsCorrect` (in `RecipesViewModelTest.kt`): This test verifies that the initial state of the `RecipesViewModel` is correct, ensuring that the recipes list is empty and the loading state is false.

- [x] **Tests modified**:
  - `fetchRandomRecipesUpdatesState` (in `RecipesViewModelTest.kt`): Added an assertion to check that the loading state is set to false after fetching recipes.
    ```kotlin
    assertThat(recipesViewModel.loading.value, `is`(false)) // Check loading is false after fetching
    ```

- [ ] Documentation updated.
- [x] All CI checks passed.
- [x] Linked issue/feature: #107 