### PR TITLE
Create build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
         java-version: '11'
 
@@ -22,7 +22,7 @@ jobs:
       run: ./gradlew assembleRelease
 
     - name: Upload APK
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: release-apk
         path: app/build/outputs/apk/release/*.apk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Android APK Build
+
+on:
+  push:
+    branches:
+      - 'release/**' # Only trigger on branches starting with 'release/'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v2
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: '11'
+
+    - name: Build APK
+      run: ./gradlew assembleRelease
+
+    - name: Upload APK
+      uses: actions/upload-artifact@v2
+      with:
+        name: release-apk
+        path: app/build/outputs/apk/release/*.apk


### PR DESCRIPTION
### GitHub Actions: Run APK build on `release/` branches only

## Description
- **What has been changed?**
  - The GitHub Actions workflow has been updated to trigger the APK build and upload only when something is pushed to a branch that starts with `release/`.
  - Removed the step for creating a GitHub release; now the workflow just builds and uploads the APK as an artifact.

- **Why was this change made?**
  - This change ensures that the APK build process is triggered only on `release/` branches, allowing us to maintain separate builds for different release stages without creating a GitHub release for each push.

## Checklist
- [ ] Tests added. *(N/A for CI workflow changes)*
- [x] Documentation updated.
- [x] All CI checks passed.
- [ ] Linked issue/feature (if applicable): N/A
