### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches:
       - 'release/**' # Only trigger on branches starting with 'release/'
-
+      
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,8 +19,14 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
+        distribution: 'zulu'
         java-version: '11'
+        cache: 'gradle'
 
+      # Run Build Project
+    - name: Build gradle project
+      run: ./gradlew build
+        
     - name: Build APK
       run: ./gradlew assembleRelease
 


### PR DESCRIPTION
### Add JDK distribution (Zulu) and Gradle cache to the build workflow

## Description
- **What has been changed?**
  - Set the JDK distribution to `zulu` in the GitHub Actions workflow.
  - Enabled Gradle caching for faster builds by adding `cache: 'gradle'`.
  - Added a step to build the Gradle project using `./gradlew build`.

- **Why was this change made?**
  - The JDK distribution (`zulu`) was specified to resolve the build issues and ensure compatibility with the project.
  - Gradle caching was added to improve build times, especially in CI environments, by reusing dependencies and avoiding redundant downloads.
  - The explicit `./gradlew build` command ensures that the project is properly built during the CI process.

## Checklist
- [ ] Tests added. *(N/A for CI workflow changes)*
- [ ] Documentation updated.
- [x] All CI checks passed.
- [ ] Linked issue/feature (if applicable): N/A
