### PR TITLE
fix: add functionality that signs out the precendent user when launch…

### DIFF
--- a/app/src/main/java/com/android/sample/MainActivity.kt
+++ b/app/src/main/java/com/android/sample/MainActivity.kt
@@ -28,10 +28,21 @@ import com.android.sample.ui.recipe.CreateRecipeScreen
 import com.android.sample.ui.recipe.SearchRecipeScreen
 import com.android.sample.ui.swipePage.SwipePage
 import com.android.sample.ui.theme.SampleAppTheme
+import com.google.firebase.auth.FirebaseAuth
 
 class MainActivity : ComponentActivity() {
+
+  private lateinit var auth: FirebaseAuth
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    // Initialize Firebase Auth
+    auth = FirebaseAuth.getInstance()
+    auth.currentUser?.let {
+      // Sign out the user if they are already signed in
+      // This is useful for testing purposes
+      auth.signOut()
+    }
     setContent {
       SampleAppTheme {
         Surface(


### PR DESCRIPTION
## Description
- [x] What has been changed?
Added lines that deconnect the current user when starting the app.

### Code added
```kotlin
auth = FirebaseAuth.getInstance()
    auth.currentUser?.let {
      // Sign out the user if they are already signed in
      // This is useful for testing purposes
      auth.signOut()
    }
```
- [x] Why was this change made?
To enable smooth testing, because of an error that the user can't connect due to concurrent users.


## Checklist
- [ ] Tests added.
- [ ] Documentation updated.
- [x] All CI checks passed.
- [ ] Linked issue/feature (if applicable):
