### PR TITLE
Add interfaces to manage FilterPage and RecipeOverview

### DIFF
--- a/app/src/main/java/com/android/sample/model/filter/FilterPageViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/filter/FilterPageViewModel.kt
@@ -14,9 +14,7 @@ interface FilterPageViewModel {
    *
    * @param difficulty The difficulty to filter by.
    */
-  fun updateDifficulty(difficulty: Difficulty) {
-    filter.value.difficulty = difficulty
-  }
+  fun updateDifficulty(difficulty: Difficulty)
 
   /**
    * Updates the price range filter.
@@ -24,9 +22,7 @@ interface FilterPageViewModel {
    * @param min The minimum price.
    * @param max The maximum price.
    */
-  fun updatePriceRange(min: Float, max: Float) {
-    filter.value.priceRange.update(min, max)
-  }
+  fun updatePriceRange(min: Float, max: Float)
 
   /**
    * Updates the time range filter.
@@ -34,16 +30,12 @@ interface FilterPageViewModel {
    * @param min The minimum time.
    * @param max The maximum time.
    */
-  fun updateTimeRange(min: Float, max: Float) {
-    filter.value.timeRange.update(min, max)
-  }
+  fun updateTimeRange(min: Float, max: Float)
 
   /**
    * Updates the category filter.
    *
    * @param category The category to filter by.
    */
-  fun updateCategory(category: String?) {
-    filter.value.category = category
-  }
+  fun updateCategory(category: String?)
 }

--- a/app/src/main/java/com/android/sample/model/filter/FilterPageViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/filter/FilterPageViewModel.kt
@@ -1,0 +1,49 @@
+package com.android.sample.model.filter
+
+import kotlinx.coroutines.flow.StateFlow
+
+interface FilterPageViewModel {
+  val filter: StateFlow<Filter>
+  val categories: StateFlow<List<String>>
+
+  /** Fetches the list of categories from the repository. */
+  fun getCategoryList()
+
+  /**
+   * Updates the difficulty filter.
+   *
+   * @param difficulty The difficulty to filter by.
+   */
+  fun updateDifficulty(difficulty: Difficulty) {
+    filter.value.difficulty = difficulty
+  }
+
+  /**
+   * Updates the price range filter.
+   *
+   * @param min The minimum price.
+   * @param max The maximum price.
+   */
+  fun updatePriceRange(min: Float, max: Float) {
+    filter.value.priceRange.update(min, max)
+  }
+
+  /**
+   * Updates the time range filter.
+   *
+   * @param min The minimum time.
+   * @param max The maximum time.
+   */
+  fun updateTimeRange(min: Float, max: Float) {
+    filter.value.timeRange.update(min, max)
+  }
+
+  /**
+   * Updates the category filter.
+   *
+   * @param category The category to filter by.
+   */
+  fun updateCategory(category: String?) {
+    filter.value.category = category
+  }
+}

--- a/app/src/main/java/com/android/sample/model/recipe/RecipeOverviewViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/recipe/RecipeOverviewViewModel.kt
@@ -1,0 +1,9 @@
+package com.android.sample.model.recipe
+
+import kotlinx.coroutines.flow.StateFlow
+
+/** Interface for the recipe overview view model. */
+interface RecipeOverviewViewModel {
+  /** The current recipe to display */
+  val currentRecipe: StateFlow<Recipe?>
+}

--- a/app/src/main/java/com/android/sample/model/recipe/RecipesViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/recipe/RecipesViewModel.kt
@@ -4,8 +4,8 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import com.android.sample.model.filter.Difficulty
 import com.android.sample.model.filter.Filter
+import com.android.sample.model.filter.FilterPageViewModel
 import com.android.sample.resources.C.Tag.MINIMUM_RECIPES_BEFORE_FETCH
 import com.android.sample.resources.C.Tag.NUMBER_RECIPES_TO_FETCH
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,7 +18,8 @@ import okhttp3.OkHttpClient
  *
  * @property repository The repository used to fetch recipe data.
  */
-class RecipesViewModel(private val repository: RecipesRepository) : ViewModel() {
+class RecipesViewModel(private val repository: RecipesRepository) :
+    ViewModel(), FilterPageViewModel, RecipeOverviewViewModel {
 
   // StateFlow to monitor the list of recipes
   private val _recipes = MutableStateFlow<List<Recipe>>(emptyList())
@@ -32,7 +33,7 @@ class RecipesViewModel(private val repository: RecipesRepository) : ViewModel() 
 
   // StateFlow for the current selected recipe
   private val _currentRecipe = MutableStateFlow<Recipe?>(null)
-  val currentRecipe: StateFlow<Recipe?>
+  override val currentRecipe: StateFlow<Recipe?>
     get() = _currentRecipe
 
   private val _nextRecipe = MutableStateFlow<Recipe?>(null)
@@ -40,11 +41,11 @@ class RecipesViewModel(private val repository: RecipesRepository) : ViewModel() 
     get() = _nextRecipe
 
   private val _filter = MutableStateFlow(Filter())
-  val filter: StateFlow<Filter>
+  override val filter: StateFlow<Filter>
     get() = _filter
 
   private val _categories = MutableStateFlow<List<String>>(emptyList())
-  val categories: StateFlow<List<String>>
+  override val categories: StateFlow<List<String>>
     get() = _categories
 
   init {
@@ -62,7 +63,7 @@ class RecipesViewModel(private val repository: RecipesRepository) : ViewModel() 
   }
 
   /** Fetches the list of categories from the repository. */
-  private fun getCategoryList() {
+  override fun getCategoryList() {
     repository.listCategories(
         onSuccess = { categories -> _categories.value = categories },
         onFailure = { exception ->
@@ -71,40 +72,11 @@ class RecipesViewModel(private val repository: RecipesRepository) : ViewModel() 
   }
 
   /**
-   * Updates the difficulty filter.
-   *
-   * @param difficulty The difficulty to filter by.
-   */
-  fun updateDifficulty(difficulty: Difficulty) {
-    _filter.value.difficulty = difficulty
-  }
-
-  /**
-   * Updates the price range filter.
-   *
-   * @param min The minimum price.
-   * @param max The maximum price.
-   */
-  fun updatePriceRange(min: Float, max: Float) {
-    _filter.value.priceRange.update(min, max)
-  }
-
-  /**
-   * Updates the time range filter.
-   *
-   * @param min The minimum time.
-   * @param max The maximum time.
-   */
-  fun updateTimeRange(min: Float, max: Float) {
-    _filter.value.timeRange.update(min, max)
-  }
-
-  /**
    * Updates the category filter.
    *
    * @param category The category to filter by.
    */
-  fun updateCategory(category: String?) {
+  override fun updateCategory(category: String?) {
     viewModelScope.launch {
       if (category == null) {
         _recipes.value = emptyList()

--- a/app/src/main/java/com/android/sample/model/recipe/RecipesViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/recipe/RecipesViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.android.sample.model.filter.Difficulty
 import com.android.sample.model.filter.Filter
 import com.android.sample.model.filter.FilterPageViewModel
 import com.android.sample.resources.C.Tag.MINIMUM_RECIPES_BEFORE_FETCH
@@ -69,6 +70,35 @@ class RecipesViewModel(private val repository: RecipesRepository) :
         onFailure = { exception ->
           Log.e("RecipesViewModel", "Error fetching categories", exception)
         })
+  }
+
+  /**
+   * Updates the difficulty filter.
+   *
+   * @param difficulty The difficulty to filter by.
+   */
+  override fun updateDifficulty(difficulty: Difficulty) {
+    filter.value.difficulty = difficulty
+  }
+
+  /**
+   * Updates the price range filter.
+   *
+   * @param min The minimum price.
+   * @param max The maximum price.
+   */
+  override fun updatePriceRange(min: Float, max: Float) {
+    filter.value.priceRange.update(min, max)
+  }
+
+  /**
+   * Updates the time range filter.
+   *
+   * @param min The minimum time.
+   * @param max The maximum time.
+   */
+  override fun updateTimeRange(min: Float, max: Float) {
+    filter.value.timeRange.update(min, max)
   }
 
   /**

--- a/app/src/main/java/com/android/sample/ui/filter/FilterPage.kt
+++ b/app/src/main/java/com/android/sample/ui/filter/FilterPage.kt
@@ -31,10 +31,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.sample.model.filter.Difficulty
+import com.android.sample.model.filter.FilterPageViewModel
 import com.android.sample.model.filter.FloatRange
-import com.android.sample.model.recipe.RecipesViewModel
 import com.android.sample.resources.C.Tag.CATEGORY_NAME
 import com.android.sample.resources.C.Tag.DIFFICULTY_NAME
 import com.android.sample.resources.C.Tag.MAX_ITEM_IN_ROW
@@ -49,29 +48,32 @@ import com.android.sample.resources.C.Tag.TIME_RANGE_UNIT
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.utils.PlateSwipeScaffold
 
+/**
+ * Composable function to display the filter page.
+ *
+ * @param navigationActions The navigation actions.
+ * @param filterViewModel The view model to manage the filter options.
+ */
 @Composable
-fun FilterPage(
-    navigationActions: NavigationActions,
-    recipesViewModel: RecipesViewModel = viewModel(factory = RecipesViewModel.Factory)
-) {
+fun FilterPage(navigationActions: NavigationActions, filterViewModel: FilterPageViewModel) {
   val selectedItem = navigationActions.currentRoute()
   PlateSwipeScaffold(
       navigationActions = navigationActions,
       selectedItem = selectedItem,
       showBackArrow = true,
-      content = { paddingValues -> FilterBox(paddingValues, recipesViewModel) })
+      content = { paddingValues -> FilterBox(paddingValues, filterViewModel) })
 }
 
 /**
  * Composable function to display the filter options.
  *
  * @param paddingValues Padding values to apply to the composable.
- * @param recipesViewModel The view model to manage recipes.
+ * @param filterViewModel The view model to manage the filter options.
  */
 @SuppressLint("StateFlowValueCalledInComposition")
 @Composable
-fun FilterBox(paddingValues: PaddingValues, recipesViewModel: RecipesViewModel) {
-  val filter by recipesViewModel.filter.collectAsState()
+fun FilterBox(paddingValues: PaddingValues, filterViewModel: FilterPageViewModel) {
+  val filter by filterViewModel.filter.collectAsState()
   Column(
       modifier =
           Modifier.padding(paddingValues).fillMaxSize().verticalScroll(rememberScrollState())) {
@@ -81,8 +83,8 @@ fun FilterBox(paddingValues: PaddingValues, recipesViewModel: RecipesViewModel) 
             min = TIME_RANGE_MIN,
             max = TIME_RANGE_MAX,
             unit = TIME_RANGE_UNIT,
-            range = recipesViewModel.filter.value.timeRange,
-            updateRange = { newMin, newMax -> recipesViewModel.updateTimeRange(newMin, newMax) })
+            range = filter.timeRange,
+            updateRange = { newMin, newMax -> filterViewModel.updateTimeRange(newMin, newMax) })
         ValueRangeSlider(
             modifier = Modifier.testTag("priceRangeSlider"),
             name = PRICE_RANGE_NAME,
@@ -90,7 +92,7 @@ fun FilterBox(paddingValues: PaddingValues, recipesViewModel: RecipesViewModel) 
             max = PRICE_RANGE_MAX,
             unit = PRICE_RANGE_UNIT,
             range = filter.priceRange,
-            updateRange = { newMin, newMax -> recipesViewModel.updatePriceRange(newMin, newMax) })
+            updateRange = { newMin, newMax -> filterViewModel.updatePriceRange(newMin, newMax) })
 
         val difficultyLevels = listOf(Difficulty.Easy, Difficulty.Medium, Difficulty.Hard)
         val selectedDifficulty = filter.difficulty
@@ -100,11 +102,11 @@ fun FilterBox(paddingValues: PaddingValues, recipesViewModel: RecipesViewModel) 
             title = DIFFICULTY_NAME,
             items = difficultyLevels,
             selectedItem = selectedDifficulty,
-            onItemSelect = { newDifficulty -> recipesViewModel.updateDifficulty(newDifficulty) },
+            onItemSelect = { newDifficulty -> filterViewModel.updateDifficulty(newDifficulty) },
             testTagPrefix = "difficulty",
             emptyValue = emptyDifficulty)
 
-        val categories = recipesViewModel.categories.value
+        val categories = filterViewModel.categories.value
         val selectedCategory = filter.category
         val emptyCategory: String? = null
 
@@ -112,7 +114,7 @@ fun FilterBox(paddingValues: PaddingValues, recipesViewModel: RecipesViewModel) 
             title = CATEGORY_NAME,
             items = categories,
             selectedItem = selectedCategory,
-            onItemSelect = { newCategory -> recipesViewModel.updateCategory(newCategory) },
+            onItemSelect = { newCategory -> filterViewModel.updateCategory(newCategory) },
             testTagPrefix = "category",
             emptyValue = emptyCategory)
       }

--- a/app/src/main/java/com/android/sample/ui/recipeOverview/RecipeOverview.kt
+++ b/app/src/main/java/com/android/sample/ui/recipeOverview/RecipeOverview.kt
@@ -51,20 +51,29 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.rememberAsyncImagePainter
 import com.android.sample.model.recipe.Recipe
-import com.android.sample.model.recipe.RecipesViewModel
+import com.android.sample.model.recipe.RecipeOverviewViewModel
 import com.android.sample.ui.navigation.BottomNavigationMenu
 import com.android.sample.ui.navigation.LIST_TOP_LEVEL_DESTINATIONS
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.theme.goldenBronze
 import com.android.sample.ui.theme.starColor
 
+/**
+ * Composable function to display the recipe overview.
+ *
+ * @param navigationActions The navigation actions.
+ * @param recipeOverviewViewModel The view model to manage the recipe overview.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun RecipeOverview(navigationActions: NavigationActions, recipesViewModel: RecipesViewModel) {
+fun RecipeOverview(
+    navigationActions: NavigationActions,
+    recipeOverviewViewModel: RecipeOverviewViewModel
+) {
+  val currentRecipe by recipeOverviewViewModel.currentRecipe.collectAsState()
   val selectedItem = navigationActions.currentRoute()
   val height = LocalConfiguration.current.screenHeightDp.dp * 1 / 2
   val width = height * 3 / 4
-  val currentRecipe by recipesViewModel.currentRecipe.collectAsState()
   var ingredientsView by remember { mutableStateOf(false) }
   var servingsCount by remember { mutableIntStateOf(1) }
   val scrollState = rememberScrollState()


### PR DESCRIPTION
# Reusable ViewModel for Secondary Screens
## Description
This pull request includes significant changes to the `FilterPageViewModel` and `RecipeOverviewViewModel` interfaces, as well as updates to the `RecipesViewModel` class to implement these interfaces. Additionally, the `FilterPage` and `RecipeOverview` composable functions have been updated to use the new view models. The main goal of these changes is to enable both the overview screen and filter page to be compatible with multiple ViewModels.

- What has been changed?

> ### View Model Interfaces
> * Added `FilterPageViewModel` interface with methods and properties for managing filter options (`filter`, `categories`, `getCategoryList`, `updateDifficulty`, `updatePriceRange`, `updateTimeRange`, `updateCategory`).
> * Added `RecipeOverviewViewModel` interface with a property for the current recipe (`currentRecipe`).

> ### RecipesViewModel Updates
> * Updated `RecipesViewModel` to implement `FilterPageViewModel` and `RecipeOverviewViewModel` interfaces.
> ```kotlin
> class RecipesViewModel(private val repository: RecipesRepository) :
>   ViewModel(), FilterPageViewModel, RecipeOverviewViewModel {...}
> ```
> * Modified `RecipesViewModel` to override the properties and methods defined in the new interfaces (`filter`, `categories`, > `currentRecipe`, `getCategoryList`, `updateCategory`). For example :
> ```kotlin
> override val categories: StateFlow<List<String>>
>     get() = _categories
> ```

> ### Composable Function Updates
> * Updated `FilterPage` composable function to use `FilterPageViewModel` instead of `RecipesViewModel`.
> ```kotlin
> fun FilterPage(
>    navigationActions: NavigationActions,
>    recipesViewModel: RecipesViewModel = viewModel(factory = RecipesViewModel.Factory)
> ) {...}
> ```
> * Updated `FilterBox` composable function to use `FilterPageViewModel` for managing filter options.
> * Updated `RecipeOverview` composable function to use `RecipeOverviewViewModel` instead of `RecipesViewModel`.
> ```kotlin
> fun RecipeOverview( navigationActions: NavigationActions,
>    recipeOverviewViewModel: RecipeOverviewViewModel
>    
> ) {...}
> ```


-  Why was this change made?
The overview and filter pages need to be reusable across multiple screens that each use different ViewModels. This update allows us to implement shared functionality across these screens, eliminating the need to create separate ViewModels and duplicate code for each screen.

## Checklist
- [x] Documentation updated.
- [x] All CI checks passed.
- [x] Linked issue/feature (if applicable): #159
