### PR TITLE
Feature/`CreateRecipeViewModel`getters

### DIFF
--- a/app/src/main/java/com/android/sample/model/recipe/CreateRecipeViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/recipe/CreateRecipeViewModel.kt
@@ -77,7 +77,7 @@ class CreateRecipeViewModel(private val repository: FirestoreRecipesRepository) 
         newMeasurement = newMeasurement)
   }
 
-  fun getIngredientsAndMeasurments(): List<Pair<String, String>> {
+  fun getIngredientsAndMeasurements(): List<Pair<String, String>> {
     return recipeBuilder.getIngredientsAndMeasurements()
   }
 

--- a/app/src/main/java/com/android/sample/model/recipe/CreateRecipeViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/recipe/CreateRecipeViewModel.kt
@@ -77,7 +77,7 @@ class CreateRecipeViewModel(private val repository: FirestoreRecipesRepository) 
         newMeasurement = newMeasurement)
   }
 
-  fun getIngredients(): List<Pair<String, String>> {
+  fun getIngredientsAndMeasurments(): List<Pair<String, String>> {
     return recipeBuilder.getIngredientsAndMeasurements()
   }
 

--- a/app/src/main/java/com/android/sample/model/recipe/CreateRecipeViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/recipe/CreateRecipeViewModel.kt
@@ -60,6 +60,59 @@ class CreateRecipeViewModel(private val repository: FirestoreRecipesRepository) 
     recipeBuilder.addIngredientAndMeasurement(ingredient, measurement)
   }
 
+  fun removeIngredientAndMeasurement(ingredient: String, measurement: String) {
+    recipeBuilder.deleteIngredientAndMeasurement(ingredient = ingredient, measurement = measurement)
+  }
+
+  fun updateIngredientAndMeasurement(
+      ingredient: String,
+      measurement: String,
+      newIngredient: String,
+      newMeasurement: String
+  ) {
+    recipeBuilder.updateIngredientAndMeasurement(
+        ingredient = ingredient,
+        measurement = measurement,
+        newIngredient = newIngredient,
+        newMeasurement = newMeasurement)
+  }
+
+  fun getIngredients(): List<Pair<String, String>> {
+    return recipeBuilder.getIngredientsAndMeasurements()
+  }
+
+  fun getRecipeName(): String {
+    return recipeBuilder.getName()
+  }
+
+  fun getRecipeInstructions(): String {
+    return recipeBuilder.getInstructions()
+  }
+
+  fun getRecipeCategory(): String? {
+    return recipeBuilder.getCategory()
+  }
+
+  fun getRecipeArea(): String? {
+    return recipeBuilder.getArea()
+  }
+
+  fun getRecipeThumbnail(): String {
+    return recipeBuilder.getPictureID()
+  }
+
+  fun getRecipeTime(): String? {
+    return recipeBuilder.getTime()
+  }
+
+  fun getRecipeDifficulty(): String? {
+    return recipeBuilder.getDifficulty()
+  }
+
+  fun getRecipePrice(): String? {
+    return recipeBuilder.getPrice()
+  }
+
   fun clearPublishError() {
     _publishError.value = null
   }

--- a/app/src/test/java/com/android/sample/model/recipe/CreateRecipeViewModelTest.kt
+++ b/app/src/test/java/com/android/sample/model/recipe/CreateRecipeViewModelTest.kt
@@ -308,6 +308,6 @@ class CreateRecipeViewModelTest {
 
     createRecipeViewModel.removeIngredientAndMeasurement("Banana", "3")
     assertEquals(
-        emptyList<Pair<String, String>>(), createRecipeViewModel.getIngredientsAndMeasurments())
+        emptyList<Pair<String, String>>(), createRecipeViewModel.getIngredientsAndMeasurements())
   }
 }

--- a/app/src/test/java/com/android/sample/model/recipe/CreateRecipeViewModelTest.kt
+++ b/app/src/test/java/com/android/sample/model/recipe/CreateRecipeViewModelTest.kt
@@ -251,4 +251,62 @@ class CreateRecipeViewModelTest {
   fun `test updateRecipeInstructions throws exception for blank instructions`() {
     createRecipeViewModel.updateRecipeInstructions("")
   }
+
+  @Test
+  fun `test all getters`() {
+    val recipe = createDefaultRecipe()
+    createRecipeViewModel.updateRecipeName(recipe.strMeal)
+    createRecipeViewModel.updateRecipeInstructions(recipe.strInstructions)
+    createRecipeViewModel.updateRecipeThumbnail(recipe.strMealThumbUrl)
+    createRecipeViewModel.addIngredient("Banana", "3")
+    createRecipeViewModel.updateRecipeTime("30 minutes")
+    createRecipeViewModel.updateRecipeDifficulty("Medium")
+    createRecipeViewModel.updateRecipePrice("15.99")
+    createRecipeViewModel.updateRecipeCategory("Dessert")
+    createRecipeViewModel.updateRecipeArea("Italian")
+
+    assertEquals(recipe.strMeal, createRecipeViewModel.getRecipeName())
+    assertEquals(recipe.strInstructions, createRecipeViewModel.getRecipeInstructions())
+    assertEquals(recipe.strMealThumbUrl, createRecipeViewModel.getRecipeThumbnail())
+    assertEquals(listOf(Pair("Banana", "3")), createRecipeViewModel.getIngredients())
+    assertEquals("30 minutes", createRecipeViewModel.getRecipeTime())
+    assertEquals("Medium", createRecipeViewModel.getRecipeDifficulty())
+    assertEquals("15.99", createRecipeViewModel.getRecipePrice())
+    assertEquals("Dessert", createRecipeViewModel.getRecipeCategory())
+    assertEquals("Italian", createRecipeViewModel.getRecipeArea())
+  }
+
+  @Test
+  fun `test update ingredientAndMeasurement`() {
+    val recipe = createDefaultRecipe()
+    createRecipeViewModel.updateRecipeName(recipe.strMeal)
+    createRecipeViewModel.updateRecipeInstructions(recipe.strInstructions)
+    createRecipeViewModel.updateRecipeThumbnail(recipe.strMealThumbUrl)
+    createRecipeViewModel.addIngredient("Banana", "3")
+    createRecipeViewModel.updateRecipeTime("30 minutes")
+    createRecipeViewModel.updateRecipeDifficulty("Medium")
+    createRecipeViewModel.updateRecipePrice("15.99")
+    createRecipeViewModel.updateRecipeCategory("Dessert")
+    createRecipeViewModel.updateRecipeArea("Italian")
+
+    createRecipeViewModel.updateIngredientAndMeasurement("Banana", "3", "Apple", "4")
+    assertEquals(listOf(Pair("Apple", "4")), createRecipeViewModel.getIngredients())
+  }
+
+  @Test
+  fun `test remove ingredientAndMeasurement`() {
+    val recipe = createDefaultRecipe()
+    createRecipeViewModel.updateRecipeName(recipe.strMeal)
+    createRecipeViewModel.updateRecipeInstructions(recipe.strInstructions)
+    createRecipeViewModel.updateRecipeThumbnail(recipe.strMealThumbUrl)
+    createRecipeViewModel.addIngredient("Banana", "3")
+    createRecipeViewModel.updateRecipeTime("30 minutes")
+    createRecipeViewModel.updateRecipeDifficulty("Medium")
+    createRecipeViewModel.updateRecipePrice("15.99")
+    createRecipeViewModel.updateRecipeCategory("Dessert")
+    createRecipeViewModel.updateRecipeArea("Italian")
+
+    createRecipeViewModel.removeIngredientAndMeasurement("Banana", "3")
+    assertEquals(emptyList<Pair<String, String>>(), createRecipeViewModel.getIngredients())
+  }
 }

--- a/app/src/test/java/com/android/sample/model/recipe/CreateRecipeViewModelTest.kt
+++ b/app/src/test/java/com/android/sample/model/recipe/CreateRecipeViewModelTest.kt
@@ -268,7 +268,7 @@ class CreateRecipeViewModelTest {
     assertEquals(recipe.strMeal, createRecipeViewModel.getRecipeName())
     assertEquals(recipe.strInstructions, createRecipeViewModel.getRecipeInstructions())
     assertEquals(recipe.strMealThumbUrl, createRecipeViewModel.getRecipeThumbnail())
-    assertEquals(listOf(Pair("Banana", "3")), createRecipeViewModel.getIngredientsAndMeasurments())
+    assertEquals(listOf(Pair("Banana", "3")), createRecipeViewModel.getIngredientsAndMeasurements())
     assertEquals("30 minutes", createRecipeViewModel.getRecipeTime())
     assertEquals("Medium", createRecipeViewModel.getRecipeDifficulty())
     assertEquals("15.99", createRecipeViewModel.getRecipePrice())
@@ -290,7 +290,7 @@ class CreateRecipeViewModelTest {
     createRecipeViewModel.updateRecipeArea("Italian")
 
     createRecipeViewModel.updateIngredientAndMeasurement("Banana", "3", "Apple", "4")
-    assertEquals(listOf(Pair("Apple", "4")), createRecipeViewModel.getIngredientsAndMeasurments())
+    assertEquals(listOf(Pair("Apple", "4")), createRecipeViewModel.getIngredientsAndMeasurements())
   }
 
   @Test
@@ -307,6 +307,7 @@ class CreateRecipeViewModelTest {
     createRecipeViewModel.updateRecipeArea("Italian")
 
     createRecipeViewModel.removeIngredientAndMeasurement("Banana", "3")
-    assertEquals(emptyList<Pair<String, String>>(), createRecipeViewModel.getIngredientsAndMeasurments())
+    assertEquals(
+        emptyList<Pair<String, String>>(), createRecipeViewModel.getIngredientsAndMeasurments())
   }
 }

--- a/app/src/test/java/com/android/sample/model/recipe/CreateRecipeViewModelTest.kt
+++ b/app/src/test/java/com/android/sample/model/recipe/CreateRecipeViewModelTest.kt
@@ -268,7 +268,7 @@ class CreateRecipeViewModelTest {
     assertEquals(recipe.strMeal, createRecipeViewModel.getRecipeName())
     assertEquals(recipe.strInstructions, createRecipeViewModel.getRecipeInstructions())
     assertEquals(recipe.strMealThumbUrl, createRecipeViewModel.getRecipeThumbnail())
-    assertEquals(listOf(Pair("Banana", "3")), createRecipeViewModel.getIngredients())
+    assertEquals(listOf(Pair("Banana", "3")), createRecipeViewModel.getIngredientsAndMeasurments())
     assertEquals("30 minutes", createRecipeViewModel.getRecipeTime())
     assertEquals("Medium", createRecipeViewModel.getRecipeDifficulty())
     assertEquals("15.99", createRecipeViewModel.getRecipePrice())
@@ -290,7 +290,7 @@ class CreateRecipeViewModelTest {
     createRecipeViewModel.updateRecipeArea("Italian")
 
     createRecipeViewModel.updateIngredientAndMeasurement("Banana", "3", "Apple", "4")
-    assertEquals(listOf(Pair("Apple", "4")), createRecipeViewModel.getIngredients())
+    assertEquals(listOf(Pair("Apple", "4")), createRecipeViewModel.getIngredientsAndMeasurments())
   }
 
   @Test
@@ -307,6 +307,6 @@ class CreateRecipeViewModelTest {
     createRecipeViewModel.updateRecipeArea("Italian")
 
     createRecipeViewModel.removeIngredientAndMeasurement("Banana", "3")
-    assertEquals(emptyList<Pair<String, String>>(), createRecipeViewModel.getIngredients())
+    assertEquals(emptyList<Pair<String, String>>(), createRecipeViewModel.getIngredientsAndMeasurments())
   }
 }


### PR DESCRIPTION

## Description

### What has been changed?
This PR adds several new getters to the `CreateRecipeViewModel`, enabling retrieval of key recipe parameters. These new getters include:

```kotlin
fun getIngredients(): List<Pair<String, String>>
fun getRecipeName(): String
fun getRecipeInstructions(): String
fun getRecipeCategory(): String?
fun getRecipeArea(): String?
fun getRecipeThumbnail(): String
fun getRecipeTime(): String?
fun getRecipeDifficulty(): String?
fun getRecipePrice(): String?
```

Additionally, three new methods have been introduced for managing the ingredient and measurement lists within the view model:

```kotlin
fun updateIngredientAndMeasurement(
      ingredient: String,
      measurement: String,
      newIngredient: String,
      newMeasurement: String
  )

fun removeIngredientAndMeasurement(ingredient: String, measurement: String)
```

### Why was this change made?
These changes allow the retrieval of recipe parameters to support the creation screens, enabling smoother data handling and management of ingredients and measurements.

### Checklist
- [x] Tests added
- [ ] Documentation updated
- [x] All CI checks passed
- [x] Linked issue/feature (if applicable): #138
