### PR TITLE
ci : Add APK-Release.yml workflow

### DIFF
--- a/.github/workflows/APK-Release.yml
+++ b/.github/workflows/APK-Release.yml
@@ -1,11 +1,12 @@
-name: Android APK Build
+name: Android APK Release Build
 
 # This workflow is triggered on push events to branches that start with 'release/'.
 
 on:
   push:
     branches:
-      - 'release/**' # Only trigger on branches starting with 'release/'
+      - 'release/**'
+      - 'ci/**'
 
 
   # Allows you to run this workflow manually from the Actions tab
@@ -26,23 +27,32 @@ jobs:
           java-version: '17'
           cache: 'gradle'
 
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2.0.10
+
       # Load google-services.json and local.properties from the secrets
       - name: Decode secrets
         env:
+          KEYSTORE: ${{ secrets.KEYSTORE_BASE_64 }}
+          KEYSTORE_PROPERTIES: ${{ secrets.KEYSTORE_PROPERTIES }}
           GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
           LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
         run: |
+          echo "$KEYSTORE" | base64 --decode > ./app/upload-keystore.jks
           echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
           echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
+          echo "$KEYSTORE_PROPERTIES" | base64 --decode > ./keystore.properties
 
       - name: Change wrapper permissions
         run: chmod +x ./gradlew
 
+      # Build the APK
       - name: Build APK
-        run: ./gradlew assembleDebug --stacktrace
+        run: ./gradlew assembleRelease --stacktrace
 
-      - name: Upload APK Debug
+      # Upload the APK as an artifact
+      - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
-          name: PlateSwipe-app-debug
-          path: app/build/outputs/apk/debug/{{ github.ref_name }}.apk
+          name: app-release.apk
+          path: app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
       - 'feature/**'
       - 'chore/**'
       - 'fix/**'
+      - 'ci/**'
 
   pull_request:
     types:
@@ -74,9 +75,13 @@ jobs:
         # Load google-services.json and local.properties from the secrets
       - name: Decode secrets
         env:
+          KEYSTORE: ${{ secrets.KEYSTORE_BASE_64 }}
+          KEYSTORE_PROPERTIES: ${{ secrets.KEYSTORE_PROPERTIES }}
           GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
           LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
         run: |
+          echo "$KEYSTORE" | base64 --decode > ./app/upload-keystore.jks
+          echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
           echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
           echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
         run: |
           echo "$KEYSTORE" | base64 --decode > ./app/upload-keystore.jks
-          echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
+          echo "$KEYSTORE_PROPERTIES" | base64 --decode > ./keystore.properties
           echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
           echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,16 @@
+import java.util.Properties
+import java.io.FileInputStream
+
+// Create a variable called keystorePropertiesFile, and initialize it to your
+// keystore.properties file, in the rootProject folder.
+val keystorePropertiesFile = rootProject.file("keystore.properties")
+
+// Initialize a new Properties() object called keystoreProperties.
+val keystoreProperties = Properties()
+
+// Load your keystore.properties file into the keystoreProperties object.
+keystoreProperties.load(FileInputStream(keystorePropertiesFile))
+
 plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.jetbrainsKotlinAndroid)
@@ -27,6 +40,14 @@ android {
             useSupportLibrary = true
         }
     }
+    signingConfigs {
+        create("config") {
+            keyAlias = keystoreProperties["keyAlias"] as String
+            keyPassword = keystoreProperties["keyPassword"] as String
+            storeFile = file(keystoreProperties["storeFile"] as String)
+            storePassword = keystoreProperties["storePassword"] as String
+        }
+    }
 
     buildTypes {
         release {
@@ -35,11 +56,13 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            signingConfig = signingConfigs.getByName("config")
         }
 
         debug {
             enableUnitTestCoverage = true
             enableAndroidTestCoverage = true
+            signingConfig = signingConfigs.getByName("debug")
         }
     }
 


### PR DESCRIPTION
# APK-Release.yml workflow: Build and Sign the APK for Release

## **What has been changed?**
  - Set up a new GitHub Actions workflow (`APK-Release.yml`) to build and sign the APK for release. This workflow utilizes a secure keystore file stored as a Base64-encoded GitHub secret.
  - Added SHA-1 fingerprint of the keystore to Firebase to enable Firebase services for release builds.
  - Configured environment variables in GitHub Actions to handle keystore passwords and alias securely.

## **Why was this change made?**
  - To automate the process of building and signing the APK for release, ensuring a consistent and reproducible setup that aligns with best practices for CI/CD in Android development. This setup also streamlines Firebase configuration, allowing release builds to access Firebase services using the correct credentials.

## Where to find the Build 
On the summary of the action you can find the artifact.

![image](https://github.com/user-attachments/assets/e8e75c35-39ff-439b-84f3-2cca80b7262c)

## Tutorial 

[Here](https://github.com/PlateSwipe/PlateSwipe/wiki/Setting-Up-and-Securing-a-Keystore-for-CI-CD-with-GitHub-Actions) is a full step-by-step guide about setting Up and Securing a Keystore for CI/CD with GitHub Actions 
## Checklist

- [ ] Tests added (not applicable for CI setup but tested workflow by running multiple builds to confirm functionality).
- [x] Documentation [updated](https://github.com/PlateSwipe/PlateSwipe/wiki/Branch-Naming-Conventions) with step-by-step instructions for maintaining or updating the CI/CD setup.
- [x] All CI checks passed.
- [x] Linked issue/feature (if applicable): #181 