### PR TITLE
Refactor/change name of recipe parameters

### DIFF
--- a/app/src/androidTest/java/com/android/sample/account/AccountScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/account/AccountScreenTest.kt
@@ -45,31 +45,31 @@ class AccountScreenTest {
   private val dummyRecipes: List<Recipe> =
       listOf(
           Recipe(
-              idMeal = "1",
-              strMeal = "Spicy Arrabiata Penne",
-              strCategory = "Vegetarian",
-              strArea = "Italian",
-              strInstructions = "Instructions here...",
+              uid = "1",
+              name = "Spicy Arrabiata Penne",
+              category = "Vegetarian",
+              origin = "Italian",
+              instructions = "Instructions here...",
               strMealThumbUrl =
                   "https://www.recipetineats.com/penne-all-arrabbiata-spicy-tomato-pasta/",
               ingredientsAndMeasurements =
                   listOf(Pair("Penne", "1 pound"), Pair("Olive oil", "1/4 cup"))),
           Recipe(
-              idMeal = "2",
-              strMeal = "Chicken Curry",
-              strCategory = "Non-Vegetarian",
-              strArea = "Indian",
-              strInstructions = "Instructions here...",
+              uid = "2",
+              name = "Chicken Curry",
+              category = "Non-Vegetarian",
+              origin = "Indian",
+              instructions = "Instructions here...",
               strMealThumbUrl =
                   "https://www.foodfashionparty.com/2023/08/05/everyday-chicken-curry/",
               ingredientsAndMeasurements =
                   listOf(Pair("Chicken", "1 pound"), Pair("Curry powder", "2 tbsp"))),
           Recipe(
-              idMeal = "3",
-              strMeal = "Burger with Fries",
-              strCategory = "Fast Food",
-              strArea = "American",
-              strInstructions = "Instructions here...",
+              uid = "3",
+              name = "Burger with Fries",
+              category = "Fast Food",
+              origin = "American",
+              instructions = "Instructions here...",
               strMealThumbUrl =
                   "https://www.recipetineats.com/penne-all-arrabbiata-spicy-tomato-pasta/",
               ingredientsAndMeasurements =
@@ -102,7 +102,7 @@ class AccountScreenTest {
     composeTestRule
         .onNodeWithTag(RECIPE_TITLE_TEST_TAG, useUnmergedTree = true)
         .assertIsDisplayed()
-        .assertTextEquals(dummyRecipes[0].strMeal)
+        .assertTextEquals(dummyRecipes[0].name)
   }
 
   @Test
@@ -119,7 +119,7 @@ class AccountScreenTest {
     composeTestRule
         .onNodeWithTag(RECIPE_TITLE_TEST_TAG, useUnmergedTree = true)
         .assertIsDisplayed()
-        .assertTextEquals(dummyRecipes[0].strMeal)
+        .assertTextEquals(dummyRecipes[0].name)
   }
 
   @Test
@@ -133,14 +133,14 @@ class AccountScreenTest {
     composeTestRule
         .onNodeWithTag(RECIPE_TITLE_TEST_TAG, useUnmergedTree = true)
         .assertIsDisplayed()
-        .assertTextEquals(dummyRecipes[1].strMeal)
+        .assertTextEquals(dummyRecipes[1].name)
 
     composeTestRule.onNodeWithTag(LIKED_RECIPES_BUTTON_TEST_TAG).performClick()
     composeTestRule.waitForIdle()
     composeTestRule
         .onNodeWithTag(RECIPE_TITLE_TEST_TAG, useUnmergedTree = true)
         .assertIsDisplayed()
-        .assertTextEquals(dummyRecipes[0].strMeal)
+        .assertTextEquals(dummyRecipes[0].name)
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/sample/e2e/End2EndTest.kt
+++ b/app/src/androidTest/java/com/android/sample/e2e/End2EndTest.kt
@@ -47,7 +47,6 @@ import com.android.sample.resources.C.TestTag.RecipeList.RECIPE_FAVORITE_ICON_TE
 import com.android.sample.resources.C.TestTag.RecipeList.RECIPE_TITLE_TEST_TAG
 import com.android.sample.resources.C.TestTag.RecipeOverview.RECIPE_TITLE
 import com.android.sample.resources.C.TestTag.SwipePage.DRAGGABLE_ITEM
-import com.android.sample.resources.C.TestTag.SwipePage.FILTER
 import com.android.sample.resources.C.TestTag.Utils.BACK_ARROW_ICON
 import com.android.sample.ui.account.AccountScreen
 import com.android.sample.ui.camera.CameraScanCodeBarScreen
@@ -292,14 +291,14 @@ class EndToEndTest {
 
     composeTestRule
         .onNodeWithTag(RECIPE_TITLE_TEST_TAG, useUnmergedTree = true)
-        .assertTextContains(likedRecipe.strMeal)
+        .assertTextContains(likedRecipe.name)
 
     composeTestRule.onNodeWithTag(RECIPE_CARD_TEST_TAG, useUnmergedTree = true).performClick()
 
     composeTestRule
         .onNodeWithTag(RECIPE_TITLE, useUnmergedTree = true)
         .assertExists()
-        .assertTextContains(likedRecipe.strMeal)
+        .assertTextContains(likedRecipe.name)
 
     composeTestRule
         .onNodeWithTag(BACK_ARROW_ICON, useUnmergedTree = true)

--- a/app/src/androidTest/java/com/android/sample/utils/RecipeListTest.kt
+++ b/app/src/androidTest/java/com/android/sample/utils/RecipeListTest.kt
@@ -88,11 +88,11 @@ class RecipeListTest {
 
   private val testRecipe =
       Recipe(
-          idMeal = "12345",
-          strMeal = "Test Recipe",
-          strCategory = "Test Category",
-          strArea = "Test Area",
-          strInstructions = "Test Instructions",
+          uid = "12345",
+          name = "Test Recipe",
+          category = "Test Category",
+          origin = "Test Area",
+          instructions = "Test Instructions",
           strMealThumbUrl = "https://example.com/image.jpg",
           ingredientsAndMeasurements = listOf(Pair("1", "Test Ingredient")),
       )

--- a/app/src/main/java/com/android/sample/model/recipe/FirestoreRecipesRepository.kt
+++ b/app/src/main/java/com/android/sample/model/recipe/FirestoreRecipesRepository.kt
@@ -35,7 +35,7 @@ class FirestoreRecipesRepository(private val db: FirebaseFirestore) : RecipesRep
   override fun addRecipe(recipe: Recipe, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
     performFirestoreOperation(
         db.collection(FIRESTORE_COLLECTION_NAME)
-            .document(recipe.idMeal)
+            .document(recipe.uid)
             .set(recipe.toFirestoreMap()),
         onSuccess,
         onFailure)
@@ -44,7 +44,7 @@ class FirestoreRecipesRepository(private val db: FirebaseFirestore) : RecipesRep
   override fun updateRecipe(recipe: Recipe, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
     performFirestoreOperation(
         db.collection(FIRESTORE_COLLECTION_NAME)
-            .document(recipe.idMeal)
+            .document(recipe.uid)
             .set(recipe.toFirestoreMap()),
         onSuccess,
         onFailure)
@@ -81,11 +81,11 @@ class FirestoreRecipesRepository(private val db: FirebaseFirestore) : RecipesRep
       val measurements = measurementsData.mapNotNull { it as? String }
 
       Recipe(
-          idMeal = id,
-          strMeal = name,
-          strCategory = category,
-          strArea = area,
-          strInstructions = instructions,
+          uid = id,
+          name = name,
+          category = category,
+          origin = area,
+          instructions = instructions,
           strMealThumbUrl = pictureID,
           ingredientsAndMeasurements = ingredients.zip(measurements),
           time = time,

--- a/app/src/main/java/com/android/sample/model/recipe/FirestoreRecipesRepository.kt
+++ b/app/src/main/java/com/android/sample/model/recipe/FirestoreRecipesRepository.kt
@@ -34,18 +34,14 @@ class FirestoreRecipesRepository(private val db: FirebaseFirestore) : RecipesRep
 
   override fun addRecipe(recipe: Recipe, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
     performFirestoreOperation(
-        db.collection(FIRESTORE_COLLECTION_NAME)
-            .document(recipe.uid)
-            .set(recipe.toFirestoreMap()),
+        db.collection(FIRESTORE_COLLECTION_NAME).document(recipe.uid).set(recipe.toFirestoreMap()),
         onSuccess,
         onFailure)
   }
 
   override fun updateRecipe(recipe: Recipe, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
     performFirestoreOperation(
-        db.collection(FIRESTORE_COLLECTION_NAME)
-            .document(recipe.uid)
-            .set(recipe.toFirestoreMap()),
+        db.collection(FIRESTORE_COLLECTION_NAME).document(recipe.uid).set(recipe.toFirestoreMap()),
         onSuccess,
         onFailure)
   }

--- a/app/src/main/java/com/android/sample/model/recipe/Recipe.kt
+++ b/app/src/main/java/com/android/sample/model/recipe/Recipe.kt
@@ -15,11 +15,11 @@ import com.android.sample.resources.C.Tag.FIRESTORE_RECIPE_URL
 /**
  * Data class representing a recipe.
  *
- * @property idMeal The unique identifier for the meal, represented as a String.
- * @property strMeal The name of the meal.
- * @property strCategory The category of the meal (e.g., Vegetarian, Non-Vegetarian). Nullable.
- * @property strArea The area or cuisine of the meal (e.g., Italian, Indian). Nullable.
- * @property strInstructions Instructions on how to prepare the meal.
+ * @property uid The unique identifier for the meal, represented as a String.
+ * @property name The name of the meal.
+ * @property category The category of the meal (e.g., Vegetarian, Non-Vegetarian). Nullable.
+ * @property origin The area or cuisine of the meal (e.g., Italian, Indian). Nullable.
+ * @property instructions Instructions on how to prepare the meal.
  * @property strMealThumbUrl URL of the thumbnail image of the meal.
  * @property ingredientsAndMeasurements A list of ingredient and measurement pairs for the recipe.
  * @property time The time required to prepare the meal. Nullable.
@@ -27,11 +27,11 @@ import com.android.sample.resources.C.Tag.FIRESTORE_RECIPE_URL
  * @property price The price of the meal. Nullable.
  */
 data class Recipe(
-    val idMeal: String,
-    val strMeal: String,
-    val strCategory: String? = null,
-    val strArea: String? = null,
-    val strInstructions: String,
+    val uid: String,
+    val name: String,
+    val category: String? = null,
+    val origin: String? = null,
+    val instructions: String,
     val strMealThumbUrl: String,
     val ingredientsAndMeasurements: List<Pair<String, String>>,
     val time: String? = null,
@@ -49,11 +49,11 @@ data class Recipe(
   /** Returns the list of ingredients and measurements. */
   fun toFirestoreMap(): Map<String, Any?> {
     return mapOf(
-        FIRESTORE_RECIPE_NAME to strMeal,
-        FIRESTORE_RECIPE_CATEGORY to strCategory,
-        FIRESTORE_RECIPE_AREA to strArea,
+        FIRESTORE_RECIPE_NAME to name,
+        FIRESTORE_RECIPE_CATEGORY to category,
+        FIRESTORE_RECIPE_AREA to origin,
         FIRESTORE_RECIPE_PICTURE_ID to strMealThumbUrl,
-        FIRESTORE_RECIPE_INSTRUCTIONS to strInstructions,
+        FIRESTORE_RECIPE_INSTRUCTIONS to instructions,
         FIRESTORE_RECIPE_INGREDIENTS to ingredientsAndMeasurements.map { it.first },
         FIRESTORE_RECIPE_MEASUREMENTS to ingredientsAndMeasurements.map { it.second },
         FIRESTORE_RECIPE_TIME to time,

--- a/app/src/main/java/com/android/sample/model/recipe/RecipeBuilder.kt
+++ b/app/src/main/java/com/android/sample/model/recipe/RecipeBuilder.kt
@@ -7,11 +7,11 @@ import com.android.sample.resources.C.Tag.ERROR_STR_THUMBNAIL
 
 /** Builder class for creating a Recipe instance. */
 class RecipeBuilder {
-  private var idMeal: String = ""
-  private var strMeal: String = ""
-  private var strCategory: String? = null
-  private var strArea: String? = null
-  private var strInstructions: String = ""
+  private var uid: String = ""
+  private var name: String = ""
+  private var category: String? = null
+  private var origin: String? = null
+  private var instructions: String = ""
   private var strMealThumbUrl: String = ""
   private val ingredientsAndMeasurements: MutableList<Pair<String, String>> = mutableListOf()
   private var time: String? = null
@@ -24,28 +24,28 @@ class RecipeBuilder {
    *
    * @param idMeal The ID of the recipe.
    */
-  fun setId(idMeal: String) = apply { this.idMeal = idMeal }
+  fun setId(idMeal: String) = apply { this.uid = idMeal }
 
   /**
    * Sets the name of the recipe.
    *
    * @param strMeal The name of the recipe.
    */
-  fun setName(strMeal: String) = apply { this.strMeal = strMeal }
+  fun setName(strMeal: String) = apply { this.name = strMeal }
 
   /**
    * Sets the category of the recipe.
    *
    * @param strCategory The category of the recipe.
    */
-  fun setCategory(strCategory: String) = apply { this.strCategory = strCategory }
+  fun setCategory(strCategory: String) = apply { this.category = strCategory }
 
   /**
    * Sets the area of the recipe.
    *
    * @param strArea The area of the recipe.
    */
-  fun setArea(strArea: String) = apply { this.strArea = strArea }
+  fun setArea(strArea: String) = apply { this.origin = strArea }
 
   /**
    * Sets the instructions for the recipe. WARNING : This method should be updated in the next
@@ -53,7 +53,7 @@ class RecipeBuilder {
    *
    * @param strInstructions The instructions for the recipe.
    */
-  fun setInstructions(strInstructions: String) = apply { this.strInstructions = strInstructions }
+  fun setInstructions(strInstructions: String) = apply { this.instructions = strInstructions }
 
   /**
    * Sets the UID of the thumbnail image for the recipe.
@@ -144,16 +144,16 @@ class RecipeBuilder {
    */
   fun build(): Recipe {
     // Validation for essential fields
-    require(strMeal.isNotBlank()) { ERROR_STR_MEAL_BLANK }
-    require(strInstructions.isNotBlank()) { ERROR_STR_INSTR_BLANK }
+    require(name.isNotBlank()) { ERROR_STR_MEAL_BLANK }
+    require(instructions.isNotBlank()) { ERROR_STR_INSTR_BLANK }
     require(ingredientsAndMeasurements.isNotEmpty()) { ERROR_LIST_INGREDIENT_EMPTY }
     require(strMealThumbUrl.isNotBlank()) { ERROR_STR_THUMBNAIL }
     return Recipe(
-        uid = idMeal,
-        name = strMeal,
-        category = strCategory,
-        origin = strArea,
-        instructions = strInstructions,
+        uid = uid,
+        name = name,
+        category = category,
+        origin = origin,
+        instructions = instructions,
         strMealThumbUrl = strMealThumbUrl,
         ingredientsAndMeasurements = ingredientsAndMeasurements,
         time = time,
@@ -164,11 +164,11 @@ class RecipeBuilder {
 
   /** Clears all fields in the builder. */
   fun clear() {
-    this.idMeal = ""
-    this.strMeal = ""
-    this.strCategory = null
-    this.strArea = null
-    this.strInstructions = ""
+    this.uid = ""
+    this.name = ""
+    this.category = null
+    this.origin = null
+    this.instructions = ""
     this.strMealThumbUrl = ""
     this.ingredientsAndMeasurements.clear()
     this.time = null
@@ -182,35 +182,35 @@ class RecipeBuilder {
    *
    * @return The ID of the recipe.
    */
-  fun getId(): String = idMeal
+  fun getId(): String = uid
 
   /**
    * Returns the name of the recipe.
    *
    * @return The name of the recipe.
    */
-  fun getName(): String = strMeal
+  fun getName(): String = name
 
   /**
    * Returns the category of the recipe.
    *
    * @return The category of the recipe.
    */
-  fun getCategory(): String? = strCategory
+  fun getCategory(): String? = category
 
   /**
    * Returns the area of the recipe.
    *
    * @return The area of the recipe.
    */
-  fun getArea(): String? = strArea
+  fun getArea(): String? = origin
 
   /**
    * Returns the instructions for the recipe.
    *
    * @return The instructions for the recipe.
    */
-  fun getInstructions(): String = strInstructions
+  fun getInstructions(): String = instructions
 
   /**
    * Returns the URL of the thumbnail image for the recipe.
@@ -263,6 +263,6 @@ class RecipeBuilder {
    * @param i The index of the instruction.
    */
   fun getInstruction(i: Int): String {
-    return strInstructions
+    return instructions
   }
 }

--- a/app/src/main/java/com/android/sample/model/recipe/RecipeBuilder.kt
+++ b/app/src/main/java/com/android/sample/model/recipe/RecipeBuilder.kt
@@ -149,11 +149,11 @@ class RecipeBuilder {
     require(ingredientsAndMeasurements.isNotEmpty()) { ERROR_LIST_INGREDIENT_EMPTY }
     require(strMealThumbUrl.isNotBlank()) { ERROR_STR_THUMBNAIL }
     return Recipe(
-        idMeal = idMeal,
-        strMeal = strMeal,
-        strCategory = strCategory,
-        strArea = strArea,
-        strInstructions = strInstructions,
+        uid = idMeal,
+        name = strMeal,
+        category = strCategory,
+        origin = strArea,
+        instructions = strInstructions,
         strMealThumbUrl = strMealThumbUrl,
         ingredientsAndMeasurements = ingredientsAndMeasurements,
         time = time,

--- a/app/src/main/java/com/android/sample/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/user/UserViewModel.kt
@@ -116,8 +116,8 @@ class UserViewModel(
                       userName = userName.value ?: userId,
                       profilePictureUrl = "",
                       fridge = _fridge.value.map { Pair(it.first.barCode.toString(), it.second) },
-                      likedRecipes = _likedRecipes.value.map { it.idMeal },
-                      createdRecipes = _createdRecipes.value.map { it.idMeal }),
+                      likedRecipes = _likedRecipes.value.map { it.uid },
+                      createdRecipes = _createdRecipes.value.map { it.uid }),
               onSuccess = { getCurrentUser() },
               onFailure = { e -> throw e })
         })
@@ -134,8 +134,8 @@ class UserViewModel(
             userName = _userName.value ?: "",
             profilePictureUrl = _profilePictureUrl.value ?: "",
             fridge = _fridge.value.map { Pair(it.first.barCode.toString(), it.second) },
-            likedRecipes = _likedRecipes.value.map { it.idMeal },
-            createdRecipes = _createdRecipes.value.map { it.idMeal })
+            likedRecipes = _likedRecipes.value.map { it.uid },
+            createdRecipes = _createdRecipes.value.map { it.uid })
 
     userRepository.updateUser(user = savedUser, onSuccess = {}, onFailure = { e -> throw e })
   }

--- a/app/src/main/java/com/android/sample/ui/recipeOverview/RecipeOverview.kt
+++ b/app/src/main/java/com/android/sample/ui/recipeOverview/RecipeOverview.kt
@@ -259,13 +259,13 @@ private fun RecipeImage(currentRecipe: Recipe) {
 private fun RecipeDescription(currentRecipe: Recipe) {
   Column(horizontalAlignment = Alignment.Start, modifier = Modifier.padding(start = PADDING.dp)) {
     Text(
-        text = currentRecipe.strMeal,
+        text = currentRecipe.name,
         modifier = Modifier.testTag(RECIPE_TITLE),
         style = MaterialTheme.typography.bodyLarge,
         color = MaterialTheme.colorScheme.onSecondary)
 
     Spacer(modifier = Modifier.size(SMALL_PADDING.dp))
-    currentRecipe.strCategory?.let { Tag(it) }
+    currentRecipe.category?.let { Tag(it) }
     Spacer(modifier = Modifier.size(SMALL_PADDING.dp))
     Row(
         horizontalArrangement = Arrangement.Start,
@@ -527,7 +527,7 @@ private fun InstructionView(currentRecipe: Recipe) {
         // Display of the instructions
 
         Text(
-            text = currentRecipe.strInstructions,
+            text = currentRecipe.instructions,
             color = Color.Black,
             style = MaterialTheme.typography.bodyMedium,
             modifier = Modifier.testTag(INSTRUCTIONS_TEXT))

--- a/app/src/main/java/com/android/sample/ui/swipePage/SwipePage.kt
+++ b/app/src/main/java/com/android/sample/ui/swipePage/SwipePage.kt
@@ -384,7 +384,7 @@ fun RecipeDisplay(
 
               // Image Description
               ImageDescription(
-                  currentRecipe?.strMeal ?: LOADING, currentRecipe?.strCategory ?: LOADING)
+                  currentRecipe?.name ?: LOADING, currentRecipe?.category ?: LOADING)
 
               Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
                 ShawRecipeButton(navigationActions)

--- a/app/src/main/java/com/android/sample/ui/swipePage/SwipePage.kt
+++ b/app/src/main/java/com/android/sample/ui/swipePage/SwipePage.kt
@@ -383,8 +383,7 @@ fun RecipeDisplay(
               }
 
               // Image Description
-              ImageDescription(
-                  currentRecipe?.name ?: LOADING, currentRecipe?.category ?: LOADING)
+              ImageDescription(currentRecipe?.name ?: LOADING, currentRecipe?.category ?: LOADING)
 
               Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
                 ShawRecipeButton(navigationActions)

--- a/app/src/main/java/com/android/sample/ui/utils/RecipeList.kt
+++ b/app/src/main/java/com/android/sample/ui/utils/RecipeList.kt
@@ -195,8 +195,8 @@ private fun RecipeCategories(recipe: Recipe) {
   Row(
       modifier = Modifier.testTag(RECIPE_CATEGORIES_TEST_TAG),
       horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-        if (recipe.strCategory?.isNotEmpty() == true) {
-          for (category in recipe.strCategory.split(",")) {
+        if (recipe.category?.isNotEmpty() == true) {
+          for (category in recipe.category.split(",")) {
             Tag(category)
           }
         }
@@ -219,7 +219,7 @@ private fun RecipeImage(recipe: Recipe) {
 private fun RecipeTitle(recipe: Recipe, modifier: Modifier) {
   Text(
       modifier = modifier.testTag(RECIPE_TITLE_TEST_TAG),
-      text = recipe.strMeal,
+      text = recipe.name,
       style = MaterialTheme.typography.titleSmall,
       fontWeight = FontWeight.Bold,
       maxLines = 1,

--- a/app/src/test/java/com/android/sample/model/recipe/CreateRecipeViewModelTest.kt
+++ b/app/src/test/java/com/android/sample/model/recipe/CreateRecipeViewModelTest.kt
@@ -80,7 +80,7 @@ class CreateRecipeViewModelTest {
     assertEquals(
         newName,
         createRecipeViewModel.recipeBuilder.javaClass
-            .getDeclaredField("strMeal")
+            .getDeclaredField("name")
             .apply { isAccessible = true }
             .get(createRecipeViewModel.recipeBuilder))
   }
@@ -92,7 +92,7 @@ class CreateRecipeViewModelTest {
     assertEquals(
         newCategory,
         createRecipeViewModel.recipeBuilder.javaClass
-            .getDeclaredField("strCategory")
+            .getDeclaredField("category")
             .apply { isAccessible = true }
             .get(createRecipeViewModel.recipeBuilder))
   }
@@ -104,7 +104,7 @@ class CreateRecipeViewModelTest {
     assertEquals(
         newInstructions,
         createRecipeViewModel.recipeBuilder.javaClass
-            .getDeclaredField("strInstructions")
+            .getDeclaredField("instructions")
             .apply { isAccessible = true }
             .get(createRecipeViewModel.recipeBuilder))
   }
@@ -415,7 +415,7 @@ class CreateRecipeViewModelTest {
 
     val updatedArea =
         createRecipeViewModel.recipeBuilder.javaClass
-            .getDeclaredField("strArea")
+            .getDeclaredField("origin")
             .apply { isAccessible = true }
             .get(createRecipeViewModel.recipeBuilder)
 

--- a/app/src/test/java/com/android/sample/model/recipe/CreateRecipeViewModelTest.kt
+++ b/app/src/test/java/com/android/sample/model/recipe/CreateRecipeViewModelTest.kt
@@ -53,11 +53,11 @@ class CreateRecipeViewModelTest {
 
   private fun createDefaultRecipe(): Recipe {
     return Recipe(
-        idMeal = "unique-id",
-        strMeal = "Test Recipe",
-        strCategory = "Dessert",
-        strArea = "Italian",
-        strInstructions = "Some instructions",
+        uid = "unique-id",
+        name = "Test Recipe",
+        category = "Dessert",
+        origin = "Italian",
+        instructions = "Some instructions",
         strMealThumbUrl = "unique-id",
         ingredientsAndMeasurements = listOf(Pair("Banana", "3")),
         url = null)
@@ -175,7 +175,7 @@ class CreateRecipeViewModelTest {
     assert(createRecipeViewModel.photo.value == null)
     val defaultRecipe = createDefaultRecipe()
     // Check that the exception is thrown with the correct message
-    `when`(mockRepository.getNewUid()).thenReturn(defaultRecipe.idMeal)
+    `when`(mockRepository.getNewUid()).thenReturn(defaultRecipe.uid)
 
     createRecipeViewModel.publishRecipe(onSuccess = {}, onFailure = {})
 
@@ -186,7 +186,7 @@ class CreateRecipeViewModelTest {
   fun `test publishRecipe() with non null image call uploadImage`() {
     val defaultRecipe = createDefaultRecipe()
     // Check that the exception is thrown with the correct message
-    `when`(mockRepository.getNewUid()).thenReturn(defaultRecipe.idMeal)
+    `when`(mockRepository.getNewUid()).thenReturn(defaultRecipe.uid)
     val bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888)
     createRecipeViewModel.setBitmap(bitmap, 90)
     createRecipeViewModel.publishRecipe(onSuccess = {}, onFailure = {})
@@ -198,7 +198,7 @@ class CreateRecipeViewModelTest {
   fun `test publishRecipe() fail to Upload Image throw IllegalArgument`() {
     val defaultRecipe = createDefaultRecipe()
     // Check that the exception is thrown with the correct message
-    `when`(mockRepository.getNewUid()).thenReturn(defaultRecipe.idMeal)
+    `when`(mockRepository.getNewUid()).thenReturn(defaultRecipe.uid)
     val bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888)
     createRecipeViewModel.setBitmap(bitmap, 90)
     `when`(
@@ -217,12 +217,12 @@ class CreateRecipeViewModelTest {
   fun `test publisRecipe() with correct image call getImageUrl`() = runTest {
     val defaultRecipe = createDefaultRecipe()
     val bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888)
-    createRecipeViewModel.updateRecipeName(defaultRecipe.strMeal)
-    createRecipeViewModel.updateRecipeInstructions(defaultRecipe.strInstructions)
+    createRecipeViewModel.updateRecipeName(defaultRecipe.name)
+    createRecipeViewModel.updateRecipeInstructions(defaultRecipe.instructions)
     createRecipeViewModel.addIngredient("Banana", "3")
     createRecipeViewModel.setBitmap(bitmap, 90)
 
-    `when`(mockRepository.getNewUid()).thenReturn(defaultRecipe.idMeal)
+    `when`(mockRepository.getNewUid()).thenReturn(defaultRecipe.uid)
 
     `when`(
             mockImageRepository.uploadImage(
@@ -245,15 +245,15 @@ class CreateRecipeViewModelTest {
     val defaultRecipe = createDefaultRecipe()
     val bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888)
 
-    createRecipeViewModel.updateRecipeName(defaultRecipe.strMeal)
-    createRecipeViewModel.updateRecipeInstructions(defaultRecipe.strInstructions)
+    createRecipeViewModel.updateRecipeName(defaultRecipe.name)
+    createRecipeViewModel.updateRecipeInstructions(defaultRecipe.instructions)
     createRecipeViewModel.updateRecipeThumbnail(defaultRecipe.strMealThumbUrl)
     createRecipeViewModel.addIngredient("Banana", "3")
-    defaultRecipe.strCategory?.let { createRecipeViewModel.updateRecipeCategory(it) }
-    defaultRecipe.strArea?.let { createRecipeViewModel.updateRecipeArea(it) }
+    defaultRecipe.category?.let { createRecipeViewModel.updateRecipeCategory(it) }
+    defaultRecipe.origin?.let { createRecipeViewModel.updateRecipeArea(it) }
     createRecipeViewModel.setBitmap(bitmap, 90)
 
-    `when`(mockRepository.getNewUid()).thenReturn(defaultRecipe.idMeal)
+    `when`(mockRepository.getNewUid()).thenReturn(defaultRecipe.uid)
 
     `when`(
             mockImageRepository.uploadImage(
@@ -286,10 +286,10 @@ class CreateRecipeViewModelTest {
     verify(mockRepository)
         .addRecipe(recipeCaptor.capture(), onSuccessCaptor.capture(), onFailureCaptor.capture())
 
-    assertEquals(defaultRecipe.idMeal, recipeCaptor.firstValue.idMeal)
-    assertEquals(defaultRecipe.strMeal, recipeCaptor.firstValue.strMeal)
-    assertEquals(defaultRecipe.strInstructions, recipeCaptor.firstValue.strInstructions)
-    assertEquals(defaultRecipe.idMeal, recipeCaptor.firstValue.strMealThumbUrl)
+    assertEquals(defaultRecipe.uid, recipeCaptor.firstValue.uid)
+    assertEquals(defaultRecipe.name, recipeCaptor.firstValue.name)
+    assertEquals(defaultRecipe.instructions, recipeCaptor.firstValue.instructions)
+    assertEquals(defaultRecipe.uid, recipeCaptor.firstValue.strMealThumbUrl)
     assertEquals(
         defaultRecipe.ingredientsAndMeasurements,
         recipeCaptor.firstValue.ingredientsAndMeasurements)
@@ -304,12 +304,12 @@ class CreateRecipeViewModelTest {
     val defaultRecipe = createDefaultRecipe()
     val bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888)
 
-    createRecipeViewModel.updateRecipeName(defaultRecipe.strMeal)
-    createRecipeViewModel.updateRecipeInstructions(defaultRecipe.strInstructions)
+    createRecipeViewModel.updateRecipeName(defaultRecipe.name)
+    createRecipeViewModel.updateRecipeInstructions(defaultRecipe.instructions)
     createRecipeViewModel.addIngredient("Banana", "3")
     createRecipeViewModel.setBitmap(bitmap, 90)
 
-    `when`(mockRepository.getNewUid()).thenReturn(defaultRecipe.idMeal)
+    `when`(mockRepository.getNewUid()).thenReturn(defaultRecipe.uid)
 
     `when`(
             mockImageRepository.uploadImage(
@@ -337,12 +337,12 @@ class CreateRecipeViewModelTest {
     val defaultRecipe = createDefaultRecipe()
     val bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888)
 
-    createRecipeViewModel.updateRecipeName(defaultRecipe.strMeal)
-    createRecipeViewModel.updateRecipeInstructions(defaultRecipe.strInstructions)
+    createRecipeViewModel.updateRecipeName(defaultRecipe.name)
+    createRecipeViewModel.updateRecipeInstructions(defaultRecipe.instructions)
     createRecipeViewModel.addIngredient("Banana", "3")
     createRecipeViewModel.setBitmap(bitmap, 90)
 
-    `when`(mockRepository.getNewUid()).thenReturn(defaultRecipe.idMeal)
+    `when`(mockRepository.getNewUid()).thenReturn(defaultRecipe.uid)
     createRecipeViewModel.setBitmap(bitmap, 90)
     // Define the onFailure callback to validate if it was called correctly
     var onFailureCalled = false
@@ -362,7 +362,7 @@ class CreateRecipeViewModelTest {
           val onSuccessCallback = invocation.arguments[4] as () -> Unit
           onSuccessCallback()
         }
-    `when`(mockRepository.getNewUid()).thenReturn(defaultRecipe.idMeal)
+    `when`(mockRepository.getNewUid()).thenReturn(defaultRecipe.uid)
 
     `when`(
             mockImageRepository.getImageUrl(
@@ -445,8 +445,8 @@ class CreateRecipeViewModelTest {
   @Test
   fun `test all getters`() {
     val recipe = createDefaultRecipe()
-    createRecipeViewModel.updateRecipeName(recipe.strMeal)
-    createRecipeViewModel.updateRecipeInstructions(recipe.strInstructions)
+    createRecipeViewModel.updateRecipeName(recipe.name)
+    createRecipeViewModel.updateRecipeInstructions(recipe.instructions)
     createRecipeViewModel.updateRecipeThumbnail(recipe.strMealThumbUrl)
     createRecipeViewModel.addIngredient("Banana", "3")
     createRecipeViewModel.updateRecipeTime("30 minutes")
@@ -455,8 +455,8 @@ class CreateRecipeViewModelTest {
     createRecipeViewModel.updateRecipeCategory("Dessert")
     createRecipeViewModel.updateRecipeArea("Italian")
 
-    assertEquals(recipe.strMeal, createRecipeViewModel.getRecipeName())
-    assertEquals(recipe.strInstructions, createRecipeViewModel.getRecipeInstructions())
+    assertEquals(recipe.name, createRecipeViewModel.getRecipeName())
+    assertEquals(recipe.instructions, createRecipeViewModel.getRecipeInstructions())
     assertEquals(recipe.strMealThumbUrl, createRecipeViewModel.getRecipeThumbnail())
     assertEquals(listOf(Pair("Banana", "3")), createRecipeViewModel.getIngredientsAndMeasurements())
     assertEquals("30 minutes", createRecipeViewModel.getRecipeTime())
@@ -469,8 +469,8 @@ class CreateRecipeViewModelTest {
   @Test
   fun `test update ingredientAndMeasurement`() {
     val recipe = createDefaultRecipe()
-    createRecipeViewModel.updateRecipeName(recipe.strMeal)
-    createRecipeViewModel.updateRecipeInstructions(recipe.strInstructions)
+    createRecipeViewModel.updateRecipeName(recipe.name)
+    createRecipeViewModel.updateRecipeInstructions(recipe.instructions)
     createRecipeViewModel.updateRecipeThumbnail(recipe.strMealThumbUrl)
     createRecipeViewModel.addIngredient("Banana", "3")
     createRecipeViewModel.updateRecipeTime("30 minutes")
@@ -486,8 +486,8 @@ class CreateRecipeViewModelTest {
   @Test
   fun `test remove ingredientAndMeasurement`() {
     val recipe = createDefaultRecipe()
-    createRecipeViewModel.updateRecipeName(recipe.strMeal)
-    createRecipeViewModel.updateRecipeInstructions(recipe.strInstructions)
+    createRecipeViewModel.updateRecipeName(recipe.name)
+    createRecipeViewModel.updateRecipeInstructions(recipe.instructions)
     createRecipeViewModel.updateRecipeThumbnail(recipe.strMealThumbUrl)
     createRecipeViewModel.addIngredient("Banana", "3")
     createRecipeViewModel.updateRecipeTime("30 minutes")

--- a/app/src/test/java/com/android/sample/model/recipe/FirestoreRecipesRepositoryTest.kt
+++ b/app/src/test/java/com/android/sample/model/recipe/FirestoreRecipesRepositoryTest.kt
@@ -51,11 +51,11 @@ class FirestoreRecipesRepositoryTest {
 
   private val recipe =
       Recipe(
-          idMeal = "1",
-          strMeal = "Chicken",
-          strCategory = "Main",
-          strArea = "Italian",
-          strInstructions = "Instructions",
+          uid = "1",
+          name = "Chicken",
+          category = "Main",
+          origin = "Italian",
+          instructions = "Instructions",
           strMealThumbUrl = "https://www.themealdb.com/images/media/meals/1548772327.jpg",
           ingredientsAndMeasurements = listOf(Pair("Chicken", "1"), Pair("Salt", "1 tsp")),
           time = "30 mins",
@@ -132,7 +132,7 @@ class FirestoreRecipesRepositoryTest {
   @Test
   fun search_callsDocuments() {
     // Ensure that mockQuerySnapshot is properly initialized and mocked
-    `when`(mockCollectionReference.document(recipe.idMeal)).thenReturn(mockDocumentReference)
+    `when`(mockCollectionReference.document(recipe.uid)).thenReturn(mockDocumentReference)
 
     // Ensure the QuerySnapshot returns a list of mock DocumentSnapshots
     `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
@@ -170,11 +170,11 @@ class FirestoreRecipesRepositoryTest {
     val recipe = firestoreFirebaseRepository.documentToRecipe(document)
 
     assertNotNull(recipe)
-    assertEquals("1", recipe?.idMeal)
-    assertEquals("Test Recipe", recipe?.strMeal)
-    assertEquals("Category", recipe?.strCategory)
-    assertEquals("Area", recipe?.strArea)
-    assertEquals("Instructions", recipe?.strInstructions)
+    assertEquals("1", recipe?.uid)
+    assertEquals("Test Recipe", recipe?.name)
+    assertEquals("Category", recipe?.category)
+    assertEquals("Area", recipe?.origin)
+    assertEquals("Instructions", recipe?.instructions)
     assertEquals("ThumbUrl", recipe?.strMealThumbUrl)
     assertEquals(
         listOf("Ingredient1" to "Measurement1", "Ingredient2" to "Measurement2"),
@@ -286,7 +286,7 @@ class FirestoreRecipesRepositoryTest {
         { recipes ->
           assertNotNull(recipes)
           assertEquals(1, recipes.size)
-          assertEquals("Test Recipe", recipes[0].strMeal)
+          assertEquals("Test Recipe", recipes[0].name)
         },
         { fail("Failure callback should not be called") },
         10)
@@ -353,8 +353,8 @@ class FirestoreRecipesRepositoryTest {
         mealID = "1",
         onSuccess = { recipe ->
           assertNotNull(recipe)
-          assertEquals("Chicken", recipe.strMeal)
-          assertEquals("Instructions", recipe.strInstructions)
+          assertEquals("Chicken", recipe.name)
+          assertEquals("Instructions", recipe.instructions)
           assertEquals("https://image.url", recipe.strMealThumbUrl)
           assertEquals(
               listOf("Chicken" to "1", "Salt" to "1 tsp"), recipe.ingredientsAndMeasurements)
@@ -425,7 +425,7 @@ class FirestoreRecipesRepositoryTest {
         onSuccess = { recipes ->
           assertNotNull(recipes)
           assertEquals(1, recipes.size)
-          assertEquals("Test Recipe", recipes[0].strMeal)
+          assertEquals("Test Recipe", recipes[0].name)
         },
         onFailure = { fail("Failure callback should not be called") })
 

--- a/app/src/test/java/com/android/sample/model/recipe/MealDBRecipesRepositoryTest.kt
+++ b/app/src/test/java/com/android/sample/model/recipe/MealDBRecipesRepositoryTest.kt
@@ -274,12 +274,12 @@ class MealDBRecipesRepositoryTest {
 
     assertNull(searchException)
     assertNotNull(searchRecipe)
-    assert(searchRecipe?.get(0)?.idMeal == "52771")
-    assert(searchRecipe?.get(0)?.strMeal == "Spicy Arrabiata Penne")
-    assert(searchRecipe?.get(0)?.strCategory == "Vegetarian")
-    assert(searchRecipe?.get(0)?.strArea == "Italian")
+    assert(searchRecipe?.get(0)?.uid == "52771")
+    assert(searchRecipe?.get(0)?.name == "Spicy Arrabiata Penne")
+    assert(searchRecipe?.get(0)?.category == "Vegetarian")
+    assert(searchRecipe?.get(0)?.origin == "Italian")
     assert(
-        searchRecipe?.get(0)?.strInstructions ==
+        searchRecipe?.get(0)?.instructions ==
             "Bring a large pot of water to a boil. Add kosher salt to the boiling water, then add the pasta. Cook according to the package instructions, about 9 minutes.\r\nIn a large skillet over medium-high heat, add the olive oil and heat until the oil starts to shimmer. Add the garlic and cook, stirring, until fragrant, 1 to 2 minutes. Add the chopped tomatoes, red chile flakes, Italian seasoning and salt and pepper to taste. Bring to a boil and cook for 5 minutes. Remove from the heat and add the chopped basil.\r\nDrain the pasta and add it to the sauce. Garnish with Parmigiano-Reggiano flakes and more basil and serve warm.")
     assert(
         searchRecipe?.get(0)?.strMealThumbUrl ==
@@ -330,12 +330,12 @@ class MealDBRecipesRepositoryTest {
     assertNull(searchException)
     assert(searchRecipe?.size == 3)
     assertNotNull(searchRecipe)
-    assert(searchRecipe?.get(0)?.idMeal == "52771")
-    assert(searchRecipe?.get(0)?.strMeal == "Spicy Arrabiata Penne")
-    assert(searchRecipe?.get(0)?.strCategory == "Vegetarian")
-    assert(searchRecipe?.get(0)?.strArea == "Italian")
+    assert(searchRecipe?.get(0)?.uid == "52771")
+    assert(searchRecipe?.get(0)?.name == "Spicy Arrabiata Penne")
+    assert(searchRecipe?.get(0)?.category == "Vegetarian")
+    assert(searchRecipe?.get(0)?.origin == "Italian")
     assert(
-        searchRecipe?.get(0)?.strInstructions ==
+        searchRecipe?.get(0)?.instructions ==
             "Bring a large pot of water to a boil. Add kosher salt to the boiling water, then add the pasta. Cook according to the package instructions, about 9 minutes.\r\nIn a large skillet over medium-high heat, add the olive oil and heat until the oil starts to shimmer. Add the garlic and cook, stirring, until fragrant, 1 to 2 minutes. Add the chopped tomatoes, red chile flakes, Italian seasoning and salt and pepper to taste. Bring to a boil and cook for 5 minutes. Remove from the heat and add the chopped basil.\r\nDrain the pasta and add it to the sauce. Garnish with Parmigiano-Reggiano flakes and more basil and serve warm.")
     assert(
         searchRecipe?.get(0)?.strMealThumbUrl ==
@@ -353,12 +353,12 @@ class MealDBRecipesRepositoryTest {
                 Pair("basil", "6 leaves"),
                 Pair("Parmigiano-Reggiano", "spinkling")))
 
-    assert(searchRecipe?.get(1)?.idMeal == "52989")
-    assert(searchRecipe?.get(1)?.strMeal == "Christmas Pudding Trifle")
-    assert(searchRecipe?.get(1)?.strCategory == "Dessert")
-    assert(searchRecipe?.get(1)?.strArea == "British")
+    assert(searchRecipe?.get(1)?.uid == "52989")
+    assert(searchRecipe?.get(1)?.name == "Christmas Pudding Trifle")
+    assert(searchRecipe?.get(1)?.category == "Dessert")
+    assert(searchRecipe?.get(1)?.origin == "British")
     assert(
-        searchRecipe?.get(1)?.strInstructions ==
+        searchRecipe?.get(1)?.instructions ==
             "Peel the oranges using a sharp knife, ensuring all the pith is removed. Slice as thinly as possible and arrange over a dinner plate. Sprinkle with the demerara sugar followed by the Grand Marnier and set aside.\r\n\r\nCrumble the Christmas pudding into large pieces and scatter over the bottom of a trifle bowl. Lift the oranges onto the pudding in a layer and pour over any juices.\r\n\r\nBeat the mascarpone until smooth, then stir in the custard. Spoon the mixture over the top of the oranges.\r\n\r\nLightly whip the cream and spoon over the custard. Sprinkle with the flaked almonds and grated chocolate. You can make this a day in advance if you like, chill until ready to serve.")
     assert(
         searchRecipe?.get(1)?.strMealThumbUrl ==
@@ -376,12 +376,12 @@ class MealDBRecipesRepositoryTest {
                 Pair("Flaked Almonds", "Handful"),
                 Pair("Dark Chocolate", "Grated")))
 
-    assert(searchRecipe?.get(2)?.idMeal == "52774")
-    assert(searchRecipe?.get(2)?.strMeal == "Pad See Ew")
-    assert(searchRecipe?.get(2)?.strCategory == "Chicken")
-    assert(searchRecipe?.get(2)?.strArea == "Thai")
+    assert(searchRecipe?.get(2)?.uid == "52774")
+    assert(searchRecipe?.get(2)?.name == "Pad See Ew")
+    assert(searchRecipe?.get(2)?.category == "Chicken")
+    assert(searchRecipe?.get(2)?.origin == "Thai")
     assert(
-        searchRecipe?.get(2)?.strInstructions ==
+        searchRecipe?.get(2)?.instructions ==
             "Mix Sauce in small bowl.\r\nMince garlic into wok with oil. Place over high heat, when hot, add chicken and Chinese broccoli stems, cook until chicken is light golden.\r\nPush to the side of the wok, crack egg in and scramble. Don't worry if it sticks to the bottom of the wok - it will char and which adds authentic flavour.\r\nAdd noodles, Chinese broccoli leaves and sauce. Gently mix together until the noodles are stained dark and leaves are wilted. Serve immediately!")
     assert(
         searchRecipe?.get(2)?.strMealThumbUrl ==
@@ -453,12 +453,12 @@ class MealDBRecipesRepositoryTest {
 
     assertNull(searchException)
     assertNotNull(searchRecipe)
-    assert(searchRecipe?.idMeal == "52771")
-    assert(searchRecipe?.strMeal == "Spicy Arrabiata Penne")
-    assert(searchRecipe?.strCategory == "Vegetarian")
-    assert(searchRecipe?.strArea == "Italian")
+    assert(searchRecipe?.uid == "52771")
+    assert(searchRecipe?.name == "Spicy Arrabiata Penne")
+    assert(searchRecipe?.category == "Vegetarian")
+    assert(searchRecipe?.origin == "Italian")
     assert(
-        searchRecipe?.strInstructions ==
+        searchRecipe?.instructions ==
             "Bring a large pot of water to a boil. Add kosher salt to the boiling water, then add the pasta. Cook according to the package instructions, about 9 minutes.\r\nIn a large skillet over medium-high heat, add the olive oil and heat until the oil starts to shimmer. Add the garlic and cook, stirring, until fragrant, 1 to 2 minutes. Add the chopped tomatoes, red chile flakes, Italian seasoning and salt and pepper to taste. Bring to a boil and cook for 5 minutes. Remove from the heat and add the chopped basil.\r\nDrain the pasta and add it to the sauce. Garnish with Parmigiano-Reggiano flakes and more basil and serve warm.")
     assert(
         searchRecipe?.strMealThumbUrl ==
@@ -604,12 +604,12 @@ class MealDBRecipesRepositoryTest {
     assertNull(searchException)
     assertNotNull(searchRecipes)
     assert(searchRecipes?.size == 1)
-    assert(searchRecipes?.get(0)?.idMeal == "52771")
-    assert(searchRecipes?.get(0)?.strMeal == "Spicy Arrabiata Penne")
-    assert(searchRecipes?.get(0)?.strCategory == "Vegetarian")
-    assert(searchRecipes?.get(0)?.strArea == "Italian")
+    assert(searchRecipes?.get(0)?.uid == "52771")
+    assert(searchRecipes?.get(0)?.name == "Spicy Arrabiata Penne")
+    assert(searchRecipes?.get(0)?.category == "Vegetarian")
+    assert(searchRecipes?.get(0)?.origin == "Italian")
     assert(
-        searchRecipes?.get(0)?.strInstructions ==
+        searchRecipes?.get(0)?.instructions ==
             "Bring a large pot of water to a boil. Add kosher salt to the boiling water, then add the pasta. Cook according to the package instructions, about 9 minutes.\r\nIn a large skillet over medium-high heat, add the olive oil and heat until the oil starts to shimmer. Add the garlic and cook, stirring, until fragrant, 1 to 2 minutes. Add the chopped tomatoes, red chile flakes, Italian seasoning and salt and pepper to taste. Bring to a boil and cook for 5 minutes. Remove from the heat and add the chopped basil.\r\nDrain the pasta and add it to the sauce. Garnish with Parmigiano-Reggiano flakes and more basil and serve warm.")
     assert(
         searchRecipes?.get(0)?.strMealThumbUrl ==
@@ -623,12 +623,12 @@ class MealDBRecipesRepositoryTest {
       mealDBRecipesRepository.updateRecipe(
           recipe =
               Recipe(
-                  strMeal = "Spicy Arrabiata Penne",
-                  strCategory = "Vegetarian",
-                  strInstructions = "alal",
+                  name = "Spicy Arrabiata Penne",
+                  category = "Vegetarian",
+                  instructions = "alal",
                   strMealThumbUrl = "someurl",
-                  strArea = "Italian",
-                  idMeal = "52771",
+                  origin = "Italian",
+                  uid = "52771",
                   ingredientsAndMeasurements =
                       listOf(
                           Pair("penne rigate", "1 pound"),
@@ -655,12 +655,12 @@ class MealDBRecipesRepositoryTest {
       mealDBRecipesRepository.addRecipe(
           recipe =
               Recipe(
-                  strMeal = "Spicy Arrabiata Penne",
-                  strCategory = "Vegetarian",
-                  strInstructions = "alal",
+                  name = "Spicy Arrabiata Penne",
+                  category = "Vegetarian",
+                  instructions = "alal",
                   strMealThumbUrl = "someurl",
-                  strArea = "Italian",
-                  idMeal = "52771",
+                  origin = "Italian",
+                  uid = "52771",
                   ingredientsAndMeasurements =
                       listOf(
                           Pair("penne rigate", "1 pound"),

--- a/app/src/test/java/com/android/sample/model/recipe/RecipeBuilderTest.kt
+++ b/app/src/test/java/com/android/sample/model/recipe/RecipeBuilderTest.kt
@@ -79,8 +79,8 @@ class RecipeBuilderTest {
             }
             .build()
 
-    assertEquals("Pasta", recipe.strMeal)
-    assertEquals("Boil water, cook pasta", recipe.strInstructions)
+    assertEquals("Pasta", recipe.name)
+    assertEquals("Boil water, cook pasta", recipe.instructions)
     assertEquals("200g", recipe.ingredientsAndMeasurements[0].second)
   }
 
@@ -129,8 +129,8 @@ class RecipeBuilderTest {
             }
             .build()
 
-    assertEquals("Vegetarian", recipe.strCategory)
-    assertEquals("French", recipe.strArea)
+    assertEquals("Vegetarian", recipe.category)
+    assertEquals("French", recipe.origin)
     assertEquals("http://example.com/image.jpg", recipe.strMealThumbUrl)
     assertEquals("15 mins", recipe.time)
     assertEquals("Easy", recipe.difficulty)

--- a/app/src/test/java/com/android/sample/model/recipe/RecipeTest.kt
+++ b/app/src/test/java/com/android/sample/model/recipe/RecipeTest.kt
@@ -34,21 +34,21 @@ class RecipeTest {
     // Act
     val recipe =
         Recipe(
-            idMeal = idMeal,
-            strMeal = strMeal,
-            strCategory = strCategory,
-            strArea = strArea,
-            strInstructions = strInstructions,
+            uid = idMeal,
+            name = strMeal,
+            category = strCategory,
+            origin = strArea,
+            instructions = strInstructions,
             strMealThumbUrl = strMealThumbUrl,
             ingredientsAndMeasurements = ingredientsAndMeasurements,
             url = url)
 
     // Assert
-    assertThat(recipe.idMeal, `is`(idMeal))
-    assertThat(recipe.strMeal, `is`(strMeal))
-    assertThat(recipe.strCategory, `is`(strCategory))
-    assertThat(recipe.strArea, `is`(strArea))
-    assertThat(recipe.strInstructions, `is`(strInstructions))
+    assertThat(recipe.uid, `is`(idMeal))
+    assertThat(recipe.name, `is`(strMeal))
+    assertThat(recipe.category, `is`(strCategory))
+    assertThat(recipe.origin, `is`(strArea))
+    assertThat(recipe.instructions, `is`(strInstructions))
     assertThat(recipe.strMealThumbUrl, `is`(strMealThumbUrl))
     assertThat(recipe.ingredientsAndMeasurements, `is`(ingredientsAndMeasurements))
     assertThat(recipe.url, `is`(url))
@@ -67,21 +67,21 @@ class RecipeTest {
     // Act
     val recipe =
         Recipe(
-            idMeal = idMeal,
-            strMeal = strMeal,
-            strCategory = null, // Nullable
-            strArea = null, // Nullable
-            strInstructions = strInstructions,
+            uid = idMeal,
+            name = strMeal,
+            category = null, // Nullable
+            origin = null, // Nullable
+            instructions = strInstructions,
             strMealThumbUrl = strMealThumbUrl,
             ingredientsAndMeasurements = ingredientsAndMeasurements,
             url = null) // Nullable
 
     // Assert
-    assertThat(recipe.idMeal, `is`(idMeal))
-    assertThat(recipe.strMeal, `is`(strMeal))
-    assertThat(recipe.strCategory, `is`(nullValue())) // Use nullValue() matcher
-    assertThat(recipe.strArea, `is`(nullValue())) // Use nullValue() matcher
-    assertThat(recipe.strInstructions, `is`(strInstructions))
+    assertThat(recipe.uid, `is`(idMeal))
+    assertThat(recipe.name, `is`(strMeal))
+    assertThat(recipe.category, `is`(nullValue())) // Use nullValue() matcher
+    assertThat(recipe.origin, `is`(nullValue())) // Use nullValue() matcher
+    assertThat(recipe.instructions, `is`(strInstructions))
     assertThat(recipe.strMealThumbUrl, `is`(strMealThumbUrl))
     assertThat(recipe.ingredientsAndMeasurements, `is`(ingredientsAndMeasurements))
     assertThat(recipe.url, `is`(nullValue()))
@@ -99,11 +99,11 @@ class RecipeTest {
     val exception =
         assertThrows(IllegalArgumentException::class.java) {
           Recipe(
-              idMeal = idMeal,
-              strMeal = strMeal,
-              strCategory = null,
-              strArea = null,
-              strInstructions = strInstructions,
+              uid = idMeal,
+              name = strMeal,
+              category = null,
+              origin = null,
+              instructions = strInstructions,
               strMealThumbUrl = strMealThumbUrl,
               ingredientsAndMeasurements = emptyList())
         }
@@ -126,11 +126,11 @@ class RecipeTest {
 
     val recipe =
         Recipe(
-            idMeal = idMeal,
-            strMeal = strMeal,
-            strCategory = strCategory,
-            strArea = strArea,
-            strInstructions = strInstructions,
+            uid = idMeal,
+            name = strMeal,
+            category = strCategory,
+            origin = strArea,
+            instructions = strInstructions,
             strMealThumbUrl = strMealThumbUrl,
             ingredientsAndMeasurements = ingredientsAndMeasurements,
             time = time,

--- a/app/src/test/java/com/android/sample/model/recipe/RecipesViewModelTest.kt
+++ b/app/src/test/java/com/android/sample/model/recipe/RecipesViewModelTest.kt
@@ -34,21 +34,21 @@ class RecipesViewModelTest {
   private val dummyRecipes: List<Recipe> =
       listOf(
           Recipe(
-              idMeal = "1",
-              strMeal = "Spicy Arrabiata Penne",
-              strCategory = "Vegetarian",
-              strArea = "Italian",
-              strInstructions = "Instructions here...",
+              uid = "1",
+              name = "Spicy Arrabiata Penne",
+              category = "Vegetarian",
+              origin = "Italian",
+              instructions = "Instructions here...",
               strMealThumbUrl =
                   "https://www.recipetineats.com/penne-all-arrabbiata-spicy-tomato-pasta/",
               ingredientsAndMeasurements =
                   listOf(Pair("Penne", "1 pound"), Pair("Olive oil", "1/4 cup"))),
           Recipe(
-              idMeal = "2",
-              strMeal = "Chicken Curry",
-              strCategory = "Non-Vegetarian",
-              strArea = "Indian",
-              strInstructions = "Instructions here...",
+              uid = "2",
+              name = "Chicken Curry",
+              category = "Non-Vegetarian",
+              origin = "Indian",
+              instructions = "Instructions here...",
               strMealThumbUrl =
                   "https://www.foodfashionparty.com/2023/08/05/everyday-chicken-curry/",
               ingredientsAndMeasurements =
@@ -290,11 +290,11 @@ class RecipesViewModelTest {
     val extendedDummyRecipes =
         dummyRecipes +
             Recipe(
-                idMeal = "3",
-                strMeal = "Beef Stroganoff",
-                strCategory = "Non-Vegetarian",
-                strArea = "Russian",
-                strInstructions = "Instructions here...",
+                uid = "3",
+                name = "Beef Stroganoff",
+                category = "Non-Vegetarian",
+                origin = "Russian",
+                instructions = "Instructions here...",
                 strMealThumbUrl = "https://www.example.com/beef-stroganoff/",
                 ingredientsAndMeasurements =
                     listOf(Pair("Beef", "1 pound"), Pair("Sour cream", "1 cup")))
@@ -362,20 +362,20 @@ class RecipesViewModelTest {
         dummyRecipes +
             listOf(
                 Recipe(
-                    idMeal = "3",
-                    strMeal = "Beef Stroganoff",
-                    strCategory = "Non-Vegetarian",
-                    strArea = "Russian",
-                    strInstructions = "Instructions here...",
+                    uid = "3",
+                    name = "Beef Stroganoff",
+                    category = "Non-Vegetarian",
+                    origin = "Russian",
+                    instructions = "Instructions here...",
                     strMealThumbUrl = "https://www.example.com/beef-stroganoff/",
                     ingredientsAndMeasurements =
                         listOf(Pair("Beef", "1 pound"), Pair("Sour cream", "1 cup"))),
                 Recipe(
-                    idMeal = "4",
-                    strMeal = "Chicken Curry",
-                    strCategory = "Non-Vegetarian",
-                    strArea = "Indian",
-                    strInstructions = "Instructions here...",
+                    uid = "4",
+                    name = "Chicken Curry",
+                    category = "Non-Vegetarian",
+                    origin = "Indian",
+                    instructions = "Instructions here...",
                     strMealThumbUrl = "https://www.example.com/chicken-curry/",
                     ingredientsAndMeasurements =
                         listOf(Pair("Chicken", "1 kg"), Pair("Curry powder", "2 tbsp"))))

--- a/app/src/test/java/com/android/sample/model/user/UserViewModelTest.kt
+++ b/app/src/test/java/com/android/sample/model/user/UserViewModelTest.kt
@@ -245,8 +245,8 @@ class UserViewModelTest {
     assertEquals(userViewModel.userName.value, userExample.userName)
     assertEquals(userViewModel.profilePictureUrl.value, userExample.profilePictureUrl)
     assertEquals(userViewModel.fridge.value[0].first.name, "apple")
-    assertEquals(userViewModel.likedRecipes.value[0].idMeal, "123")
-    assertEquals(userViewModel.createdRecipes.value[0].idMeal, "123")
+    assertEquals(userViewModel.likedRecipes.value[0].uid, "123")
+    assertEquals(userViewModel.createdRecipes.value[0].uid, "123")
 
     userViewModel.removeIngredientFromUserFridge(ingredientExample)
     userViewModel.removeRecipeFromUserLikedRecipes(recipeExample)


### PR DESCRIPTION
# Pull Request: Refactor `Recipe` Parameters

## Description

### What has been changed?

This PR introduces a refactor of the `Recipe` parameters to use more intuitive and descriptive names. The following changes were made:

```kotlin
idMeal -> uid  
strMeal -> name  
strCategory -> category  
strArea -> origin  
strInstructions -> instruction  
```

### Why was this change made?

This change improves code readability and maintainability by replacing cryptic parameter names with clear, meaningful ones. This will make the codebase more accessible for future contributors and help ensure a smoother implementation process.

---

## Checklist

- [ ] Tests added to verify the changes.
- [x] Documentation updated to reflect the refactored parameters.
- [x] All CI checks passed successfully.
- [x] Linked issue/feature (if applicable): #205
