### PR TITLE
fix: handle navigation and error handling during recipe publishing

### DIFF
--- a/app/src/main/java/com/android/sample/model/recipe/CreateRecipeViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/recipe/CreateRecipeViewModel.kt
@@ -309,27 +309,32 @@ class CreateRecipeViewModel(
                   C.Tag.FIRESTORE_RECIPE_IMAGE_NAME,
                   ImageDirectoryType.RECIPE,
                   onSuccess = { uri ->
+                    try {
 
-                    // Set the URL to the Builder
-                    val url = uri.toString()
-                    recipeBuilder.setUrl(url)
+                      // Set the URL to the Builder
+                      val url = uri.toString()
+                      recipeBuilder.setUrl(url)
 
-                    // Build the Recipe
-                    val recipe = recipeBuilder.build()
+                      // Build the Recipe
+                      val recipe = recipeBuilder.build()
 
-                    // Add the Recipe to the Repository
-                    repository.addRecipe(
-                        recipe,
-                        onSuccess = {
-                          onSuccess(recipe)
-                          _publishStatus.value = RECIPE_PUBLISHED_SUCCESS_MESSAGE
-                          recipeBuilder.clear()
-                        },
-                        onFailure = { exception ->
-                          _publishStatus.value =
-                              RECIPE_PUBLISH_ERROR_MESSAGE.format(exception.message)
-                          onFailure(exception)
-                        })
+                      // Add the Recipe to the Repository
+                      repository.addRecipe(
+                          recipe,
+                          onSuccess = {
+                            onSuccess(recipe)
+                            _publishStatus.value = RECIPE_PUBLISHED_SUCCESS_MESSAGE
+                            recipeBuilder.clear()
+                          },
+                          onFailure = { exception ->
+                            _publishStatus.value =
+                                RECIPE_PUBLISH_ERROR_MESSAGE.format(exception.message)
+                            onFailure(exception)
+                          })
+                    } catch (e: IllegalArgumentException) {
+                      _publishStatus.value = e.message
+                      onFailure(e)
+                    }
                   },
                   onFailure = { exception ->
                     _publishStatus.value = RECIPE_PUBLISH_ERROR_MESSAGE.format(exception.message)

--- a/app/src/main/java/com/android/sample/ui/createRecipe/PublishRecipeScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/PublishRecipeScreen.kt
@@ -1,6 +1,5 @@
 package com.android.sample.ui.createRecipe
 
-import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
@@ -104,15 +103,12 @@ fun PublishRecipeContent(
             onClick = {
               createRecipeViewModel.publishRecipe(
                   onSuccess = { recipe ->
-                    Log.d("PublishRecipe", "Recipe successfully published: $recipe")
                     userViewModel.addRecipeToUserCreatedRecipes(recipe)
-                    Log.d("PublishRecipe", "Recipe added to user created recipes")
+                    navigationActions.navigateTo(Screen.SWIPE)
                   },
                   onFailure = { exception ->
                     Toast.makeText(context, exception.message, Toast.LENGTH_SHORT).show()
                   })
-
-              navigationActions.navigateTo(Screen.SWIPE)
             },
             colors =
                 ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),


### PR DESCRIPTION
## Description

### What has been changed?
1. **PublishRecipeScreen.kt**:
   - Moved the `navigateTo(Screen.SWIPE)` call inside the `onSuccess` callback to ensure the app only navigates after successfully publishing the recipe.

   **Code Snippet:**
   ```kotlin
   onClick = {
       createRecipeViewModel.publishRecipe(
           onSuccess = { recipe ->
               userViewModel.addRecipeToUserCreatedRecipes(recipe)
               navigationActions.navigateTo(Screen.SWIPE) // Moved here
           } 
       )
   }
   ```

2. **CreateRecipeViewModel.kt**:
   - Added a `try-catch` block around the `recipeBuilder.build()` call to gracefully handle any exceptions (e.g., missing required fields) and prevent app crashes.
   - Errors are now caught, and a toast displays the error message.

   **Code Snippet:**
   ```kotlin
   try {
       val recipe = recipeBuilder.build()
       repository.addRecipe(
          ...
       )
   } catch (e: IllegalArgumentException) {
       _publishStatus.value = e.message
       onFailure(e)
   }
   ```

---

### Why was this change made?
- The `navigateTo` call was causing the app to navigate before the success callback, which could lead to unexpected behavior and UI inconsistencies.
- Missing error handling for `recipeBuilder.build()` caused the app to crash when required fields were missing. The new implementation ensures errors are caught and displayed to the user via a toast.

---

## Checklist
- [ ] Tests added to validate the changes:
- [x] Documentation updated where applicable.
- [x] All CI checks passed.
- [x] Linked issue/feature: #205

---

### Additional Context
**Toast for Success**  | **Toast for Error**
   :-------------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/7c660aac-bf8a-493b-bfdb-562622bc2ca2) | ![image](https://github.com/user-attachments/assets/fba63df8-f41c-4e19-a559-13a98613b6d2)
