### PR TITLE
feat: add CategoryScreen to recipe creation flow

### DIFF
--- a/app/src/androidTest/java/com/android/sample/createRecipe/CategoryScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/createRecipe/CategoryScreenTest.kt
@@ -1,0 +1,112 @@
+package com.android.sample.createRecipe
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.android.sample.model.image.ImageRepositoryFirebase
+import com.android.sample.model.recipe.CreateRecipeViewModel
+import com.android.sample.model.recipe.FirestoreRecipesRepository
+import com.android.sample.model.recipe.Recipe
+import com.android.sample.ui.createRecipe.CategoryScreen
+import com.android.sample.ui.navigation.NavigationActions
+import com.android.sample.ui.navigation.Screen
+import com.google.firebase.firestore.FirebaseFirestore
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class CategoryScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private lateinit var mockNavigationActions: NavigationActions
+  private lateinit var createRecipeViewModel: CreateRecipeViewModel
+  private lateinit var repoImg: ImageRepositoryFirebase
+
+  @Before
+  fun setUp() = runTest {
+    mockNavigationActions = mockk(relaxed = true)
+
+    val firestore = mockk<FirebaseFirestore>(relaxed = true)
+    val repository = FirestoreRecipesRepository(firestore)
+    repoImg = mockk(relaxed = true)
+    createRecipeViewModel = spyk(CreateRecipeViewModel(repository, repoImg))
+  }
+
+  @Test
+  fun testCategoryScreenComponentsAreDisplayed() {
+    composeTestRule.setContent {
+      CategoryScreen(
+          navigationActions = mockNavigationActions, createRecipeViewModel = createRecipeViewModel)
+    }
+
+    composeTestRule.onNodeWithText("Select A Category").assertExists().assertIsDisplayed()
+    composeTestRule
+        .onNodeWithText(
+            "Selecting a category is optional, but it can help others find your recipe more easily.")
+        .assertExists()
+        .assertIsDisplayed()
+    composeTestRule.onNodeWithTag("DropdownMenuButton").assertExists().assertIsDisplayed()
+    composeTestRule.onNodeWithTag("NextStepButton").assertExists().assertIsDisplayed()
+    composeTestRule.onNodeWithTag("progressBar").assertExists().assertIsDisplayed()
+  }
+
+  @Test
+  fun testDropdownMenuOpensAndDisplaysCategories() {
+    composeTestRule.setContent {
+      CategoryScreen(
+          navigationActions = mockNavigationActions, createRecipeViewModel = createRecipeViewModel)
+    }
+
+    // Verify dropdown button is displayed with placeholder text
+    composeTestRule
+        .onNodeWithTag("DropdownMenuButton")
+        .assertExists()
+        .assertIsDisplayed()
+        .assertTextEquals("Choose a category")
+
+    // Click dropdown button to open menu
+    composeTestRule.onNodeWithTag("DropdownMenuButton").performClick()
+
+    // Verify each category is displayed in the dropdown menu
+    Recipe.getCategories().forEach { category ->
+      composeTestRule.onNodeWithTag("DropdownMenuItem_$category").assertExists().assertIsDisplayed()
+    }
+  }
+
+  @Test
+  fun testSelectingCategoryUpdatesButtonText() {
+    composeTestRule.setContent {
+      CategoryScreen(
+          navigationActions = mockNavigationActions, createRecipeViewModel = createRecipeViewModel)
+    }
+
+    // Open dropdown menu and select a category
+    composeTestRule.onNodeWithTag("DropdownMenuButton").performClick()
+    composeTestRule.onNodeWithTag("DropdownMenuItem_Vegan").performClick()
+
+    // Verify dropdown button text updates to the selected category
+    composeTestRule.onNodeWithTag("DropdownMenuButton").assertExists().assertTextEquals("Vegan")
+  }
+
+  @Test
+  fun testNextStepButtonNavigatesToNextScreen() {
+    composeTestRule.setContent {
+      CategoryScreen(
+          navigationActions = mockNavigationActions, createRecipeViewModel = createRecipeViewModel)
+    }
+
+    // Click the "Next Step" button
+    composeTestRule.onNodeWithTag("NextStepButton").assertExists().performClick()
+
+    // Verify navigation to the next screen
+    verify { mockNavigationActions.navigateTo(Screen.CREATE_RECIPE_INGREDIENTS) }
+  }
+}

--- a/app/src/androidTest/java/com/android/sample/createRecipe/RecipeNameScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/createRecipe/RecipeNameScreenTest.kt
@@ -109,7 +109,7 @@ class RecipeNameScreenTest {
     verify { createRecipeViewModel.updateRecipeName("Chocolate Cake") }
 
     // Verify navigation to the ingredients screen
-    verify { mockNavigationActions.navigateTo(Screen.CREATE_RECIPE_INGREDIENTS) }
+    verify { mockNavigationActions.navigateTo(Screen.CATEGORY_SCREEN) }
   }
 
   /**

--- a/app/src/androidTest/java/com/android/sample/e2e/End2EndTest.kt
+++ b/app/src/androidTest/java/com/android/sample/e2e/End2EndTest.kt
@@ -52,6 +52,7 @@ import com.android.sample.ui.account.AccountScreen
 import com.android.sample.ui.camera.CameraScanCodeBarScreen
 import com.android.sample.ui.camera.CameraTakePhotoScreen
 import com.android.sample.ui.createRecipe.AddInstructionStepScreen
+import com.android.sample.ui.createRecipe.CategoryScreen
 import com.android.sample.ui.createRecipe.CreateRecipeScreen
 import com.android.sample.ui.createRecipe.IngredientListScreen
 import com.android.sample.ui.createRecipe.IngredientSearchScreen
@@ -339,6 +340,25 @@ class EndToEndTest {
     composeTestRule.onNodeWithTag("NextStepButton").performClick()
     composeTestRule.waitForIdle()
 
+    // category -------------------------------------------------------
+
+    // Verify the category screen is displayed by checking the title
+    composeTestRule.onNodeWithText("Select A Category").assertExists()
+
+    // Open the dropdown menu
+    composeTestRule.onNodeWithTag("DropdownMenuButton").performClick()
+    composeTestRule.waitForIdle()
+
+    // Select a category from the dropdown menu
+    composeTestRule.onNodeWithTag("DropdownMenuItem_Vegan").performClick()
+    composeTestRule.waitForIdle()
+
+    // Verify the selected category is displayed in the dropdown button
+    composeTestRule.onNodeWithTag("DropdownMenuButton").assertTextEquals("Vegan")
+
+    composeTestRule.onNodeWithTag("NextStepButton").performClick()
+    composeTestRule.waitForIdle()
+
     // ingredients -------------------------------------------------------
 
     // get to ingredients step page
@@ -460,6 +480,10 @@ class EndToEndTest {
       ) {
         composable(Screen.CREATE_RECIPE) {
           CreateRecipeScreen(
+              navigationActions = navigationActions, createRecipeViewModel = createRecipeViewModel)
+        }
+        composable(Screen.CATEGORY_SCREEN) {
+          CategoryScreen(
               navigationActions = navigationActions, createRecipeViewModel = createRecipeViewModel)
         }
         composable(Screen.CREATE_RECIPE_INGREDIENTS) {

--- a/app/src/main/java/com/android/sample/MainActivity.kt
+++ b/app/src/main/java/com/android/sample/MainActivity.kt
@@ -27,6 +27,7 @@ import com.android.sample.ui.authentication.SignInScreen
 import com.android.sample.ui.camera.CameraScanCodeBarScreen
 import com.android.sample.ui.camera.CameraTakePhotoScreen
 import com.android.sample.ui.createRecipe.AddInstructionStepScreen
+import com.android.sample.ui.createRecipe.CategoryScreen
 import com.android.sample.ui.createRecipe.CreateRecipeScreen
 import com.android.sample.ui.createRecipe.IngredientListScreen
 import com.android.sample.ui.createRecipe.IngredientSearchScreen
@@ -111,6 +112,10 @@ fun PlateSwipeApp() {
       composable(Screen.CREATE_RECIPE) {
         CreateRecipeScreen(
             navigationActions = navigationActions, createRecipeViewModel = createRecipeViewModel)
+      }
+
+      composable(Screen.CATEGORY_SCREEN) {
+        CategoryScreen(navigationActions, createRecipeViewModel)
       }
       composable(Screen.CREATE_RECIPE_INGREDIENTS) {
         RecipeIngredientsScreen(

--- a/app/src/main/java/com/android/sample/ui/createRecipe/CategoryScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/CategoryScreen.kt
@@ -1,0 +1,164 @@
+package com.android.sample.ui.createRecipe
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.android.sample.R
+import com.android.sample.model.recipe.CreateRecipeViewModel
+import com.android.sample.model.recipe.Recipe
+import com.android.sample.resources.C.Tag.INITIAL_RECIPE_STEP
+import com.android.sample.resources.C.Tag.RECIPE_NAME_BASE_PADDING
+import com.android.sample.ui.navigation.NavigationActions
+import com.android.sample.ui.navigation.Route
+import com.android.sample.ui.navigation.Screen
+import com.android.sample.ui.theme.Typography
+import com.android.sample.ui.utils.PlateSwipeButton
+import com.android.sample.ui.utils.PlateSwipeScaffold
+
+@Composable
+fun CategoryScreen(
+    navigationActions: NavigationActions,
+    createRecipeViewModel: CreateRecipeViewModel,
+) {
+  PlateSwipeScaffold(
+      navigationActions = navigationActions,
+      selectedItem = Route.CREATE_RECIPE,
+      showBackArrow = true,
+      content = { paddingValues ->
+        CategoryContent(
+            currentStep = INITIAL_RECIPE_STEP,
+            navigationActions = navigationActions,
+            createRecipeViewModel = createRecipeViewModel,
+            modifier = Modifier.fillMaxSize().padding(paddingValues))
+      })
+}
+
+/**
+ * Composable function to optionally select a category for a recipe.
+ *
+ * @param modifier Modifier to be applied to the screen.
+ * @param currentStep The current step in the recipe creation process.
+ * @param navigationActions Actions for navigating between screens.
+ * @param createRecipeViewModel ViewModel for managing the recipe creation process.
+ */
+@Composable
+fun CategoryContent(
+    modifier: Modifier = Modifier,
+    currentStep: Int,
+    navigationActions: NavigationActions,
+    createRecipeViewModel: CreateRecipeViewModel
+) {
+  val categories = Recipe.getCategories()
+  val selectedCategory = remember { mutableStateOf(createRecipeViewModel.getRecipeCategory()) }
+  val expanded = remember { mutableStateOf(false) }
+
+  Box(
+      modifier = modifier.padding(RECIPE_NAME_BASE_PADDING / 2),
+      contentAlignment = Alignment.TopCenter) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Top) {
+              // Display the progress bar for the current step
+              RecipeProgressBar(currentStep = currentStep)
+
+              Spacer(modifier = Modifier.weight(0.05f))
+
+              // Title
+              Text(
+                  text = stringResource(R.string.select_category),
+                  style = Typography.displayLarge,
+                  color = MaterialTheme.colorScheme.onPrimary,
+                  modifier =
+                      Modifier.fillMaxWidth()
+                          .padding(horizontal = RECIPE_NAME_BASE_PADDING)
+                          .testTag("CategoryTitle"),
+                  textAlign = TextAlign.Center)
+
+              Spacer(modifier = Modifier.weight(0.05f))
+
+              // Subtitle
+              Text(
+                  text = stringResource(R.string.select_category_description_optional),
+                  style = MaterialTheme.typography.bodyMedium,
+                  color = MaterialTheme.colorScheme.onPrimary,
+                  modifier =
+                      Modifier.padding(horizontal = RECIPE_NAME_BASE_PADDING * 2)
+                          .testTag("CategorySubtitle"),
+                  textAlign = TextAlign.Center)
+
+              Spacer(modifier = Modifier.weight(0.1f))
+
+              // Dropdown menu for selecting category
+              Box(
+                  modifier =
+                      Modifier.fillMaxWidth().padding(horizontal = RECIPE_NAME_BASE_PADDING)) {
+                    OutlinedButton(
+                        onClick = { expanded.value = !expanded.value },
+                        modifier = Modifier.fillMaxWidth().testTag("DropdownMenuButton"),
+                        shape = RoundedCornerShape(8.dp),
+                        colors =
+                            ButtonDefaults.outlinedButtonColors(
+                                containerColor = MaterialTheme.colorScheme.surface,
+                                contentColor = MaterialTheme.colorScheme.onSurface)) {
+                          Text(
+                              text =
+                                  selectedCategory.value
+                                      ?: stringResource(R.string.select_category_placeholder),
+                              style = MaterialTheme.typography.bodyMedium,
+                              modifier = Modifier.padding(vertical = 8.dp))
+                        }
+
+                    DropdownMenu(
+                        expanded = expanded.value,
+                        onDismissRequest = { expanded.value = false },
+                        modifier =
+                            Modifier.fillMaxWidth().background(MaterialTheme.colorScheme.surface)) {
+                          categories.forEach { category ->
+                            DropdownMenuItem(
+                                text = {
+                                  Text(text = category, style = MaterialTheme.typography.bodyMedium)
+                                },
+                                onClick = {
+                                  selectedCategory.value = category
+                                  expanded.value = false
+                                },
+                                modifier = Modifier.testTag("DropdownMenuItem_$category"))
+                          }
+                        }
+                  }
+
+              Spacer(modifier = Modifier.weight(0.4f))
+            }
+
+        // Next Step Button
+        PlateSwipeButton(
+            text = stringResource(R.string.next_step),
+            modifier = Modifier.align(Alignment.BottomCenter).testTag("NextStepButton"),
+            onClick = {
+              selectedCategory.value?.let { createRecipeViewModel.updateRecipeCategory(it) }
+              navigationActions.navigateTo(Screen.CREATE_RECIPE_INGREDIENTS)
+            })
+      }
+}

--- a/app/src/main/java/com/android/sample/ui/createRecipe/RecipeNameScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/RecipeNameScreen.kt
@@ -160,9 +160,7 @@ fun RecipeNameScreen(
                   recipeName = recipeName,
                   onShowErrorChange = { showError = it },
                   onUpdateRecipeName = { createRecipeViewModel.updateRecipeName(it) },
-                  onNavigateToNextScreen = {
-                    navigationActions.navigateTo(Screen.CREATE_RECIPE_INGREDIENTS)
-                  })
+                  onNavigateToNextScreen = { navigationActions.navigateTo(Screen.CATEGORY_SCREEN) })
             })
       }
 }

--- a/app/src/main/java/com/android/sample/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/sample/ui/navigation/NavigationActions.kt
@@ -26,6 +26,8 @@ object Screen {
 
   const val CREATE_RECIPE = "AddRecipe Screen"
 
+  const val CATEGORY_SCREEN = "Category Screen"
+
   const val CREATE_RECIPE_INGREDIENTS = "Add Recipe Ingredients"
 
   const val CREATE_RECIPE_INSTRUCTIONS = "Add Recipe Instructions"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,4 +111,10 @@
     <string name="pop_up_confirm_removal_liked_recipe">Yes</string>>
     <string name="pop_up_confirm_cancel_removal_liked_recipe">No</string>
 
+    //CategoryScreen
+    <string name="select_category">Select A Category</string>
+    <string name="select_category_description_optional">Selecting a category is optional, but it can help others find your recipe more easily.</string>
+    <string name="select_category_placeholder">Choose a category</string>
+
+
 </resources>


### PR DESCRIPTION
# Description

## What has been changed?
1. **CategoryScreen.kt**:
   - Added a new `CategoryScreen` that allows users to optionally select a category for their recipe using a dropdown menu.
   - Users can skip this step if they choose not to select a category.

   **Dropdown Menu Code Snippet:**
   ```kotlin
   DropdownMenu(
       expanded = expanded.value,
       onDismissRequest = { expanded.value = false },
   ) {
       categories.forEach { category ->
           DropdownMenuItem(onClick = {
               selectedCategory.value = category
               expanded.value = false
           }) {
               Text(text = category)
           }
       }
   }
   ```

   - **Note**: Initially, I attempted to use a `LazyColumn` inside the dropdown menu to handle large category lists, but this caused app crashes due to `SubcomposeLayout` intrinsic measurement issues. As a result, I reverted to using `DropdownMenu` without `LazyColumn` for stability. I you have any idea how to solve it dont hesitate, but just note that it is optional and that it was just for esthetic purpose.

**Dropdown Menu Closed** | **Dropdown Menu Opened**
:-------------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/b9225413-d0af-41ab-b8f3-fd7afc576a02) | ![image](https://github.com/user-attachments/assets/662ab1b2-e4e5-4ea3-8a5b-a8cf800ef2af)

2. **CategoryScreenTest.kt**:
   - Added a test file to validate the UI elements and user interactions for `CategoryScreen`.
   - Verifies that:
     - The title and dropdown menu are displayed correctly.
     - Users can select a category and proceed to the next step.

   **Code Snippet:**
   ```kotlin
   composeTestRule.onNodeWithTag("DropdownMenuButton").performClick()
   composeTestRule.onNodeWithTag("DropdownMenuItem_Vegan").performClick()
   composeTestRule.onNodeWithTag("DropdownMenuButton").assertTextEquals("Vegan")
   ```

3. **RecipeNameScreen.kt**:
   - Updated the `NextStepButton` to navigate to `CategoryScreen` instead of directly proceeding to the ingredients step.

   **Code Snippet:**
   ```kotlin
   PlateSwipeButton(
       text = stringResource(R.string.next_step),
       onClick = {
           handleOnClick(
               recipeName = recipeName,
               onNavigateToNextScreen = {
                   navigationActions.navigateTo(Screen.CATEGORY)
               }
           )
       }
   )
   ```

4. **MainActivity.kt**:
   - Integrated `CategoryScreen` into the `NavHost` to enable navigation to the screen.

   **Code Snippet:**
   ```kotlin
   composable("CategoryScreen") {
       CategoryScreen(
           navigationActions = NavigationActions(navController),
           createRecipeViewModel = createRecipeViewModel
       )
   }
   ```

5. **End2EndTest.kt**:
   - Enhanced the end-to-end test to include the category selection step.
   - Verifies that the dropdown menu works as expected and that the selected category is retained when navigating forward.

---

## Why was this change made?
- To provide users with the ability to categorize their recipes, enhancing recipe discoverability and organization.
- To ensure a seamless and guided recipe creation flow where users can optionally select a category.
- The decision to avoid `LazyColumn` was made to ensure app stability and avoid crashes caused by `SubcomposeLayout` intrinsic measurement issues.

---

## Checklist
- [x] Tests added to validate the changes:
  - `CategoryScreenTest.kt`
  - Updates to `End2EndTest.kt` and `RecipeNameScreenTest.kt`
- [x] Documentation updated where applicable.
- [x] All CI checks passed.
- [x] Linked issue/feature: #205 