### PR TITLE
Feature add and delete instruction button

### DIFF
--- a/app/src/androidTest/java/com/android/sample/createRecipe/AddInstructionStepContentTest.kt
+++ b/app/src/androidTest/java/com/android/sample/createRecipe/AddInstructionStepContentTest.kt
@@ -90,7 +90,10 @@ class AddInstructionStepScreenTest {
     composeTestRule.onNodeWithTag("InstructionInput").performTextInput("Preheat oven to 180°C...")
     composeTestRule.onNodeWithTag(SAVE_BUTTON_TAG).performClick()
     advanceUntilIdle()
-    verify { navigationActions.navigateToPop(Screen.CREATE_RECIPE_LIST_INSTRUCTIONS,Screen.CREATE_RECIPE_LIST_INGREDIENTS) }
+    verify {
+      navigationActions.navigateToPop(
+          Screen.CREATE_RECIPE_LIST_INSTRUCTIONS, Screen.CREATE_RECIPE_LIST_INGREDIENTS)
+    }
   }
 
   /** Verifies that an error message is displayed when attempting to save without instructions. */

--- a/app/src/androidTest/java/com/android/sample/createRecipe/AddInstructionStepContentTest.kt
+++ b/app/src/androidTest/java/com/android/sample/createRecipe/AddInstructionStepContentTest.kt
@@ -90,7 +90,7 @@ class AddInstructionStepScreenTest {
     composeTestRule.onNodeWithTag("InstructionInput").performTextInput("Preheat oven to 180°C...")
     composeTestRule.onNodeWithTag(SAVE_BUTTON_TAG).performClick()
     advanceUntilIdle()
-    verify { navigationActions.navigateTo(Screen.CREATE_RECIPE_LIST_INSTRUCTIONS) }
+    verify { navigationActions.navigateToPop(Screen.CREATE_RECIPE_LIST_INSTRUCTIONS,Screen.CREATE_RECIPE_LIST_INGREDIENTS) }
   }
 
   /** Verifies that an error message is displayed when attempting to save without instructions. */

--- a/app/src/androidTest/java/com/android/sample/createRecipe/AddInstructionStepContentTest.kt
+++ b/app/src/androidTest/java/com/android/sample/createRecipe/AddInstructionStepContentTest.kt
@@ -1,8 +1,10 @@
 package com.android.sample.createRecipe
 
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.sample.R
 import com.android.sample.model.image.ImageRepositoryFirebase
 import com.android.sample.model.recipe.CreateRecipeViewModel
 import com.android.sample.model.recipe.FirestoreRecipesRepository
@@ -15,6 +17,7 @@ import com.android.sample.resources.C.TestTag.AddInstructionStepScreen.INSTRUCTI
 import com.android.sample.resources.C.TestTag.AddInstructionStepScreen.TIME_INPUT
 import com.android.sample.resources.C.TestTag.RecipeList.CANCEL_BUTTON
 import com.android.sample.resources.C.TestTag.RecipeList.CONFIRMATION_BUTTON
+import com.android.sample.resources.C.TestTag.RecipeList.CONFIRMATION_POP_UP
 import com.android.sample.ui.createRecipe.AddInstructionStepScreen
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
@@ -159,7 +162,15 @@ class AddInstructionStepScreenTest {
     composeTestRule.onNodeWithTag(DELETE_BUTTON).assertIsDisplayed()
     composeTestRule.onNodeWithTag(DELETE_BUTTON).performClick()
 
+    composeTestRule.onNodeWithTag(CONFIRMATION_POP_UP).assertIsDisplayed()
+
     composeTestRule.onNodeWithTag(CONFIRMATION_BUTTON).assertIsDisplayed()
     composeTestRule.onNodeWithTag(CANCEL_BUTTON).assertIsDisplayed()
+
+    composeTestRule.onNodeWithText(stringResource(R.string.delete)).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithText(stringResource(R.string.u_sure_u_want_to_delete))
+        .assertIsDisplayed()
+    composeTestRule.onNodeWithText(stringResource(R.string.cancel)).assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/android/sample/createRecipe/AddInstructionStepContentTest.kt
+++ b/app/src/androidTest/java/com/android/sample/createRecipe/AddInstructionStepContentTest.kt
@@ -6,7 +6,15 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.sample.model.image.ImageRepositoryFirebase
 import com.android.sample.model.recipe.CreateRecipeViewModel
 import com.android.sample.model.recipe.FirestoreRecipesRepository
+import com.android.sample.model.recipe.Instruction
 import com.android.sample.resources.C.Tag.SAVE_BUTTON_TAG
+import com.android.sample.resources.C.TestTag.AddInstructionStepScreen.DELETE_BUTTON
+import com.android.sample.resources.C.TestTag.AddInstructionStepScreen.ICON_DROPDOWN
+import com.android.sample.resources.C.TestTag.AddInstructionStepScreen.INPUT_CONTAINER
+import com.android.sample.resources.C.TestTag.AddInstructionStepScreen.INSTRUCTION_INPUT
+import com.android.sample.resources.C.TestTag.AddInstructionStepScreen.TIME_INPUT
+import com.android.sample.resources.C.TestTag.RecipeList.CANCEL_BUTTON
+import com.android.sample.resources.C.TestTag.RecipeList.CONFIRMATION_BUTTON
 import com.android.sample.ui.createRecipe.AddInstructionStepScreen
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
@@ -132,5 +140,26 @@ class AddInstructionStepScreenTest {
 
     // Verify time and category were updated with the new values
     verify { createRecipeViewModel.addRecipeInstruction(any()) }
+  }
+
+  @Test
+  fun AddInstructionDisplaysAlertBoxWhenTryingToDeleteTest() {
+    createRecipeViewModel.addRecipeInstruction(
+        Instruction("10", "Preheat oven to 180°C...", "Cook"))
+    createRecipeViewModel.selectInstruction(0)
+    composeTestRule.setContent {
+      AddInstructionStepScreen(
+          navigationActions = navigationActions, createRecipeViewModel = createRecipeViewModel)
+    }
+    composeTestRule.onNodeWithTag(INPUT_CONTAINER).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(TIME_INPUT).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(ICON_DROPDOWN).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(SAVE_BUTTON_TAG).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(INSTRUCTION_INPUT).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(DELETE_BUTTON).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(DELETE_BUTTON).performClick()
+
+    composeTestRule.onNodeWithTag(CONFIRMATION_BUTTON).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(CANCEL_BUTTON).assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/android/sample/createRecipe/AddInstructionStepContentTest.kt
+++ b/app/src/androidTest/java/com/android/sample/createRecipe/AddInstructionStepContentTest.kt
@@ -1,10 +1,8 @@
 package com.android.sample.createRecipe
 
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.android.sample.R
 import com.android.sample.model.image.ImageRepositoryFirebase
 import com.android.sample.model.recipe.CreateRecipeViewModel
 import com.android.sample.model.recipe.FirestoreRecipesRepository
@@ -146,7 +144,7 @@ class AddInstructionStepScreenTest {
   }
 
   @Test
-  fun AddInstructionDisplaysAlertBoxWhenTryingToDeleteTest() {
+  fun addInstructionDisplaysAlertBoxWhenTryingToDeleteTest() {
     createRecipeViewModel.addRecipeInstruction(
         Instruction("10", "Preheat oven to 180°C...", "Cook"))
     createRecipeViewModel.selectInstruction(0)
@@ -167,10 +165,7 @@ class AddInstructionStepScreenTest {
     composeTestRule.onNodeWithTag(CONFIRMATION_BUTTON).assertIsDisplayed()
     composeTestRule.onNodeWithTag(CANCEL_BUTTON).assertIsDisplayed()
 
-    composeTestRule.onNodeWithText(stringResource(R.string.delete)).assertIsDisplayed()
-    composeTestRule
-        .onNodeWithText(stringResource(R.string.u_sure_u_want_to_delete))
-        .assertIsDisplayed()
-    composeTestRule.onNodeWithText(stringResource(R.string.cancel)).assertIsDisplayed()
+    composeTestRule.onNodeWithText("Are you sure you want to delete this step?").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Cancel").assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/android/sample/createRecipe/RecipeListInstructionsScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/createRecipe/RecipeListInstructionsScreenTest.kt
@@ -8,6 +8,7 @@ import com.android.sample.model.image.ImageRepositoryFirebase
 import com.android.sample.model.recipe.CreateRecipeViewModel
 import com.android.sample.model.recipe.FirestoreRecipesRepository
 import com.android.sample.model.recipe.Instruction
+import com.android.sample.resources.C.TestTag.CreateRecipeListInstructionsScreen.ADD_INSTRUCTION_BUTTON
 import com.android.sample.resources.C.TestTag.CreateRecipeListInstructionsScreen.INSTRUCTION_LIST_ITEM
 import com.android.sample.resources.C.TestTag.CreateRecipeListInstructionsScreen.INSTRUCTION_TEXT
 import com.android.sample.resources.C.TestTag.CreateRecipeListInstructionsScreen.NEXT_STEP_BUTTON
@@ -60,6 +61,7 @@ class RecipeListInstructionsScreenTest {
     composeTestRule.onNodeWithTag(SCREEN_COLUMN).assertIsDisplayed()
     composeTestRule.onNodeWithTag(RECIPE_NAME_TEXT).assertIsDisplayed()
     composeTestRule.onNodeWithTag(INSTRUCTION_TEXT).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(ADD_INSTRUCTION_BUTTON).assertIsDisplayed()
   }
 
   // Check if everything is clickable and verify navigation action

--- a/app/src/androidTest/java/com/android/sample/utils/PlateSwipeAlertBoxTest.kt
+++ b/app/src/androidTest/java/com/android/sample/utils/PlateSwipeAlertBoxTest.kt
@@ -1,0 +1,35 @@
+package com.android.sample.utils
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import com.android.sample.resources.C.TestTag.RecipeList.CANCEL_BUTTON
+import com.android.sample.resources.C.TestTag.RecipeList.CONFIRMATION_BUTTON
+import com.android.sample.resources.C.TestTag.RecipeList.CONFIRMATION_POP_UP
+import com.android.sample.ui.utils.PlateSwipeAlertBox
+import org.junit.Rule
+import org.junit.Test
+
+class PlateSwipeAlertBoxTest {
+  @get:Rule val composeTestRule = createComposeRule()
+  private val text = "Alert Box"
+  private val confirmMessage = "Confirm"
+  private val dismissMessage = "Dismiss"
+
+  @Test
+  fun testPlateSwipeAlertBox() {
+    composeTestRule.setContent {
+      PlateSwipeAlertBox(
+          popUpMessage = text,
+          confirmMessage = confirmMessage,
+          onConfirm = {},
+          dismissMessage = dismissMessage,
+          onDismiss = {},
+      )
+    }
+
+    composeTestRule.onNodeWithTag(CONFIRMATION_POP_UP).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(CONFIRMATION_BUTTON).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(CANCEL_BUTTON).assertIsDisplayed()
+  }
+}

--- a/app/src/main/java/com/android/sample/resources/C.kt
+++ b/app/src/main/java/com/android/sample/resources/C.kt
@@ -706,6 +706,7 @@ object C {
       const val RECIPE_LIST_INSTRUCTIONS_SCREEN_SPACER1 = "RecipeListInstructionsScreenSpacer1"
       const val RECIPE_LIST_ITEM_THUMBNAIL = "InstructionThumbnail"
       const val RECIPE_LIST_INSTRUCTION_ICON = "InstructionIcon"
+      const val ADD_INSTRUCTION_BUTTON = "AddInstructionButton"
     }
 
     object RecipeAddImageScreen {

--- a/app/src/main/java/com/android/sample/resources/C.kt
+++ b/app/src/main/java/com/android/sample/resources/C.kt
@@ -541,6 +541,7 @@ object C {
       const val CARD_SHADOW_ELEVATION = 8
       const val ICON_SIZE = 24
       const val ROW_SIZE = 1f
+      const val RECIPE_NAME_MAX_CHAR = 14
 
       // progress bar value
       const val CURRENT_STEP = 2

--- a/app/src/main/java/com/android/sample/resources/C.kt
+++ b/app/src/main/java/com/android/sample/resources/C.kt
@@ -713,6 +713,9 @@ object C {
       const val RECIPE_LIST_ITEM_THUMBNAIL = "InstructionThumbnail"
       const val RECIPE_LIST_INSTRUCTION_ICON = "InstructionIcon"
       const val ADD_INSTRUCTION_BUTTON = "AddInstructionButton"
+      const val ADD_ICON_DESCRIPTION = "Add"
+      const val EDIT_ICON_DESCRIPTION = "Edit"
+      const val STEP_ICON_DESCRIPTION = "Step"
     }
 
     object RecipeAddImageScreen {

--- a/app/src/main/java/com/android/sample/resources/C.kt
+++ b/app/src/main/java/com/android/sample/resources/C.kt
@@ -754,5 +754,14 @@ object C {
     object RecipeBuilder {
       const val OUT_OF_BOUNDS_MESSAGE = "Index out of bounds"
     }
+
+    object AddInstructionStepScreen {
+      const val INPUT_CONTAINER = "InputContainer"
+      const val TIME_INPUT = "TimeInput"
+      const val ICON_DROPDOWN = "IconDropdown"
+      const val INSTRUCTION_INPUT = "InstructionInput"
+      const val INSTRUCTION_ERROR = "InstructionError"
+      const val DELETE_BUTTON = "DeleteButton"
+    }
   }
 }

--- a/app/src/main/java/com/android/sample/ui/createRecipe/AddInstructionStepScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/AddInstructionStepScreen.kt
@@ -27,6 +27,12 @@ import com.android.sample.resources.C.Tag.MINLINES_VISIBLE_FOR_INSTRUCTION
 import com.android.sample.resources.C.Tag.SAVE_BUTTON_TAG
 import com.android.sample.resources.C.Tag.SPACE_BETWEEN_ELEMENTS
 import com.android.sample.resources.C.Tag.TIME_CHARACTER_LIMIT
+import com.android.sample.resources.C.TestTag.AddInstructionStepScreen.DELETE_BUTTON
+import com.android.sample.resources.C.TestTag.AddInstructionStepScreen.ICON_DROPDOWN
+import com.android.sample.resources.C.TestTag.AddInstructionStepScreen.INPUT_CONTAINER
+import com.android.sample.resources.C.TestTag.AddInstructionStepScreen.INSTRUCTION_ERROR
+import com.android.sample.resources.C.TestTag.AddInstructionStepScreen.INSTRUCTION_INPUT
+import com.android.sample.resources.C.TestTag.AddInstructionStepScreen.TIME_INPUT
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Route
 import com.android.sample.ui.navigation.Screen
@@ -117,7 +123,7 @@ fun AddInstructionStepContent(
                 Modifier.fillMaxWidth()
                     .background(color = lightCream, shape = RoundedCornerShape(8.dp))
                     .padding(CONTAINER_PADDING.dp)
-                    .testTag("InputContainer")) {
+                    .testTag(INPUT_CONTAINER)) {
               Column {
                 // Row for input fields for time, and icon
                 Row(
@@ -145,14 +151,14 @@ fun AddInstructionStepContent(
                                   unfocusedLabelColor = MaterialTheme.colorScheme.onSecondary,
                                   focusedBorderColor = MaterialTheme.colorScheme.onPrimary,
                                   unfocusedBorderColor = MaterialTheme.colorScheme.onSecondary),
-                          modifier = Modifier.weight(1f).testTag("TimeInput"),
+                          modifier = Modifier.weight(1f).testTag(TIME_INPUT),
                           maxLines = MAXLINES_TIME_FIELD)
 
                       // Icon dropdown menu
                       IconDropdownMenu(
                           selectedIcon = selectedIcon,
                           onIconSelected = { selectedIcon = it },
-                          modifier = Modifier.weight(1f).testTag("IconDropdown"))
+                          modifier = Modifier.weight(1f).testTag(ICON_DROPDOWN))
                     }
 
                 Spacer(modifier = Modifier.height(SPACE_BETWEEN_ELEMENTS.dp))
@@ -176,7 +182,7 @@ fun AddInstructionStepContent(
                         Modifier.fillMaxWidth()
                             .padding(vertical = INSTRUCTION_VERTICAL_PADDING.dp)
                             .verticalScroll(rememberScrollState())
-                            .testTag("InstructionInput"),
+                            .testTag(INSTRUCTION_INPUT),
                     isError = verifyStepDescription(showError, stepDescription),
                     textStyle = Typography.bodySmall,
                     minLines = MINLINES_VISIBLE_FOR_INSTRUCTION,
@@ -188,7 +194,7 @@ fun AddInstructionStepContent(
                       text = stringResource(R.string.error_message_empty_instruction),
                       style = Typography.bodySmall,
                       color = MaterialTheme.colorScheme.error,
-                      modifier = Modifier.padding(top = 4.dp).testTag("InstructionError"))
+                      modifier = Modifier.padding(top = 4.dp).testTag(INSTRUCTION_ERROR))
                 }
               }
             }
@@ -221,15 +227,15 @@ fun AddInstructionStepContent(
           // suppress button if editing an existing instruction
           PlateSwipeButton(
               stringResource(R.string.RecipeListInstructionsScreen_Delete),
-              modifier = Modifier.fillMaxWidth(),
+              modifier = Modifier.fillMaxWidth().testTag(DELETE_BUTTON),
               onClick = { isDeleting = true },
               backgroundColor = MaterialTheme.colorScheme.error,
               contentColor = MaterialTheme.colorScheme.onError)
         }
         if (isDeleting) {
           PlateSwipeAlertBox(
-              popUpMessage = "Are you sure you want to delete this step?",
-              confirmMessage = "Delete",
+              popUpMessage = stringResource(R.string.u_sure_u_want_to_delete),
+              confirmMessage = stringResource(R.string.delete),
               onConfirm = {
                 createRecipeViewModel.deleteRecipeInstruction(
                     createRecipeViewModel.getSelectedInstruction()!!)
@@ -239,7 +245,7 @@ fun AddInstructionStepContent(
                     popUpTo = Screen.CREATE_RECIPE_LIST_INGREDIENTS,
                     inclusive = false)
               },
-              dismissMessage = "Cancel",
+              dismissMessage = stringResource(R.string.cancel),
               onDismiss = { isDeleting = false },
           )
         }

--- a/app/src/main/java/com/android/sample/ui/createRecipe/AddInstructionStepScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/AddInstructionStepScreen.kt
@@ -126,8 +126,7 @@ fun AddInstructionStepContent(
                       OutlinedTextField(
                           value = stepTime ?: "",
                           onValueChange = { newValue ->
-                            if (newValue.all { char -> char.isDigit() } &&
-                                newValue.length <= TIME_CHARACTER_LIMIT) {
+                            if (checkTimeFormat(newValue)) {
                               stepTime = newValue
                             }
                           },
@@ -287,6 +286,15 @@ fun defaultIcon(createRecipeViewModel: CreateRecipeViewModel): IconType? {
  */
 fun verifyStepDescription(showError: Boolean, stepDescription: String): Boolean {
   return showError && stepDescription.isEmpty()
+}
+
+/**
+ * Checks if the time format is valid.
+ *
+ * @param time The time to be checked.
+ */
+fun checkTimeFormat(time: String): Boolean {
+  return time.all { char -> char.isDigit() } && time.length <= TIME_CHARACTER_LIMIT
 }
 
 /**

--- a/app/src/main/java/com/android/sample/ui/createRecipe/AddInstructionStepScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/AddInstructionStepScreen.kt
@@ -32,6 +32,7 @@ import com.android.sample.ui.navigation.Route
 import com.android.sample.ui.navigation.Screen
 import com.android.sample.ui.theme.Typography
 import com.android.sample.ui.theme.lightCream
+import com.android.sample.ui.utils.PlateSwipeAlertBox
 import com.android.sample.ui.utils.PlateSwipeButton
 import com.android.sample.ui.utils.PlateSwipeScaffold
 
@@ -94,6 +95,9 @@ fun AddInstructionStepContent(
         })
   }
   var showError by remember { mutableStateOf(false) }
+
+  // see if an instruction is being deleted
+  var isDeleting by remember { mutableStateOf(false) }
 
   Column(
       modifier =
@@ -210,6 +214,35 @@ fun AddInstructionStepContent(
                         inclusive = false)
                   })
             })
+
+        Spacer(modifier = Modifier.height(SPACE_BETWEEN_ELEMENTS.dp))
+
+        if (createRecipeViewModel.getSelectedInstruction() != null) {
+          // suppress button if editing an existing instruction
+          PlateSwipeButton(
+              stringResource(R.string.RecipeListInstructionsScreen_Delete),
+              modifier = Modifier.fillMaxWidth(),
+              onClick = { isDeleting = true },
+              backgroundColor = MaterialTheme.colorScheme.error,
+              contentColor = MaterialTheme.colorScheme.onError)
+        }
+        if (isDeleting) {
+          PlateSwipeAlertBox(
+              popUpMessage = "Are you sure you want to delete this step?",
+              confirmMessage = "Delete",
+              onConfirm = {
+                createRecipeViewModel.deleteRecipeInstruction(
+                    createRecipeViewModel.getSelectedInstruction()!!)
+                createRecipeViewModel.resetSelectedInstruction()
+                navigationActions.navigateToPop(
+                    Screen.CREATE_RECIPE_LIST_INSTRUCTIONS,
+                    popUpTo = Screen.CREATE_RECIPE_LIST_INGREDIENTS,
+                    inclusive = false)
+              },
+              dismissMessage = "Cancel",
+              onDismiss = { isDeleting = false },
+          )
+        }
       }
 }
 

--- a/app/src/main/java/com/android/sample/ui/createRecipe/AddInstructionStepScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/AddInstructionStepScreen.kt
@@ -201,43 +201,38 @@ fun AddInstructionStepContent(
 
         Spacer(modifier = Modifier.height(SPACE_BETWEEN_ELEMENTS.dp))
 
-      Row{
-
+        Row {
           if (createRecipeViewModel.getSelectedInstruction() != null) {
-              // suppress button if editing an existing instruction
-              PlateSwipeButton(
-                  stringResource(R.string.RecipeListInstructionsScreen_Delete),
-                  modifier = Modifier.testTag(DELETE_BUTTON).weight(1f),
-                  onClick = { isDeleting = true },
-                  backgroundColor = MaterialTheme.colorScheme.error,
-                  contentColor = MaterialTheme.colorScheme.onError)
+            // suppress button if editing an existing instruction
+            PlateSwipeButton(
+                stringResource(R.string.RecipeListInstructionsScreen_Delete),
+                modifier = Modifier.testTag(DELETE_BUTTON).weight(1f),
+                onClick = { isDeleting = true },
+                backgroundColor = MaterialTheme.colorScheme.error,
+                contentColor = MaterialTheme.colorScheme.onError)
           }
           // Save Button
           PlateSwipeButton(
               stringResource(R.string.save_label),
               modifier = Modifier.testTag(SAVE_BUTTON_TAG).weight(1f),
               onClick = {
-                  showError = stepDescription.isEmpty() // Set error if instructions are empty
-                  confirmAndAssignStep(
-                      stepDescription,
-                      stepTime,
-                      selectedIcon,
-                      createRecipeViewModel,
-                      onSuccess = {
-                          createRecipeViewModel.resetSelectedInstruction()
-                          navigationActions.navigateToPop(
-                              Screen.CREATE_RECIPE_LIST_INSTRUCTIONS,
-                              popUpTo = Screen.CREATE_RECIPE_LIST_INGREDIENTS,
-                              inclusive = false)
-                      })
+                showError = stepDescription.isEmpty() // Set error if instructions are empty
+                confirmAndAssignStep(
+                    stepDescription,
+                    stepTime,
+                    selectedIcon,
+                    createRecipeViewModel,
+                    onSuccess = {
+                      createRecipeViewModel.resetSelectedInstruction()
+                      navigationActions.navigateToPop(
+                          Screen.CREATE_RECIPE_LIST_INSTRUCTIONS,
+                          popUpTo = Screen.CREATE_RECIPE_LIST_INGREDIENTS,
+                          inclusive = false)
+                    })
               })
-
-      }
-
-
+        }
 
         Spacer(modifier = Modifier.height(SPACE_BETWEEN_ELEMENTS.dp))
-
 
         if (isDeleting) {
           PlateSwipeAlertBox(

--- a/app/src/main/java/com/android/sample/ui/createRecipe/AddInstructionStepScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/AddInstructionStepScreen.kt
@@ -90,16 +90,7 @@ fun AddInstructionStepContent(
             selectedInstruction = createRecipeViewModel.getSelectedInstruction(),
             onSuccess = { createRecipeViewModel.getInstruction(it).time }))
   }
-  var selectedIcon by remember {
-    mutableStateOf<IconType?>(
-        if (createRecipeViewModel.getSelectedInstruction() != null) {
-          createRecipeViewModel
-              .getInstruction(createRecipeViewModel.getSelectedInstruction()!!)
-              .icon
-        } else {
-          null
-        })
-  }
+  var selectedIcon by remember { mutableStateOf<IconType?>(defaultIcon(createRecipeViewModel)) }
   var showError by remember { mutableStateOf(false) }
 
   // see if an instruction is being deleted
@@ -254,11 +245,36 @@ fun AddInstructionStepContent(
       }
 }
 
+/**
+ * Selects the default value based on the selected instruction. If an instruction is selected, the
+ * value of the instruction is returned. Otherwise, the default value is returned.
+ *
+ * @param defaultValue The default value to be returned if no instruction is selected.
+ * @param selectedInstruction The index of the selected instruction.
+ * @param onSuccess Callback to be executed if an instruction is selected.
+ * @param T The type of the default value.
+ * @return The selected instruction if it exists, otherwise the default value.
+ */
 fun <T> defaultValues(defaultValue: T, selectedInstruction: Int?, onSuccess: (Int) -> T): T {
   return if (selectedInstruction != null) {
     onSuccess(selectedInstruction)
   } else {
     defaultValue
+  }
+}
+
+/**
+ * Selects the default icon based on the selected instruction. If an instruction is selected, the
+ * icon of the instruction is returned. Otherwise, the default icon is returned.
+ *
+ * @param createRecipeViewModel ViewModel for managing the recipe creation process.
+ * @return The selected icon if it exists, otherwise null.
+ */
+fun defaultIcon(createRecipeViewModel: CreateRecipeViewModel): IconType? {
+  return if (createRecipeViewModel.getSelectedInstruction() != null) {
+    createRecipeViewModel.getInstruction(createRecipeViewModel.getSelectedInstruction()!!).icon
+  } else {
+    null
   }
 }
 

--- a/app/src/main/java/com/android/sample/ui/createRecipe/AddInstructionStepScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/AddInstructionStepScreen.kt
@@ -206,13 +206,13 @@ fun AddInstructionStepContent(
               stringResource(R.string.save_label),
               modifier = Modifier.testTag(SAVE_BUTTON_TAG).weight(1f),
               onClick = {
-                  processValidInstruction(
-                      stepDescription = stepDescription,
-                      stepTime = stepTime,
-                      selectedIcon = selectedIcon,
-                      createRecipeViewModel = createRecipeViewModel,
-                      navigationActions = navigationActions,
-                      setShowError = { showError = it })
+                processValidInstruction(
+                    stepDescription = stepDescription,
+                    stepTime = stepTime,
+                    selectedIcon = selectedIcon,
+                    createRecipeViewModel = createRecipeViewModel,
+                    navigationActions = navigationActions,
+                    setShowError = { showError = it })
               })
         }
 
@@ -256,24 +256,22 @@ private fun processValidInstruction(
     navigationActions: NavigationActions,
     setShowError: (Boolean) -> Unit
 ) {
-    if (stepDescription.isBlank()) {
-        setShowError(true) // Trigger the error state if the instruction is blank
-    } else {
-        confirmAndAssignStep(
-            stepDescription,
-            stepTime,
-            selectedIcon,
-            createRecipeViewModel,
-            onSuccess = {
-
-                    createRecipeViewModel.resetSelectedInstruction()
-                    navigationActions.navigateToPop(
-                        Screen.CREATE_RECIPE_LIST_INSTRUCTIONS,
-                        popUpTo = Screen.CREATE_RECIPE_LIST_INGREDIENTS,
-                        inclusive = false)
-
-            })
-    }
+  if (stepDescription.isBlank()) {
+    setShowError(true) // Trigger the error state if the instruction is blank
+  } else {
+    confirmAndAssignStep(
+        stepDescription,
+        stepTime,
+        selectedIcon,
+        createRecipeViewModel,
+        onSuccess = {
+          createRecipeViewModel.resetSelectedInstruction()
+          navigationActions.navigateToPop(
+              Screen.CREATE_RECIPE_LIST_INSTRUCTIONS,
+              popUpTo = Screen.CREATE_RECIPE_LIST_INGREDIENTS,
+              inclusive = false)
+        })
+  }
 }
 
 /**

--- a/app/src/main/java/com/android/sample/ui/createRecipe/AddInstructionStepScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/AddInstructionStepScreen.kt
@@ -113,7 +113,7 @@ fun AddInstructionStepContent(
         // Step Label
         Text(
             text = stringResource(R.string.step_label),
-            style = Typography.titleLarge,
+            style = Typography.titleMedium,
             color = MaterialTheme.colorScheme.onPrimary,
             modifier = Modifier.padding(vertical = 8.dp).testTag("StepLabel"))
 
@@ -201,37 +201,44 @@ fun AddInstructionStepContent(
 
         Spacer(modifier = Modifier.height(SPACE_BETWEEN_ELEMENTS.dp))
 
-        // Save Button
-        PlateSwipeButton(
-            stringResource(R.string.save_label),
-            modifier = Modifier.fillMaxWidth().testTag(SAVE_BUTTON_TAG),
-            onClick = {
-              showError = stepDescription.isEmpty() // Set error if instructions are empty
-              confirmAndAssignStep(
-                  stepDescription,
-                  stepTime,
-                  selectedIcon,
-                  createRecipeViewModel,
-                  onSuccess = {
-                    createRecipeViewModel.resetSelectedInstruction()
-                    navigationActions.navigateToPop(
-                        Screen.CREATE_RECIPE_LIST_INSTRUCTIONS,
-                        popUpTo = Screen.CREATE_RECIPE_LIST_INGREDIENTS,
-                        inclusive = false)
-                  })
-            })
+      Row{
+
+          if (createRecipeViewModel.getSelectedInstruction() != null) {
+              // suppress button if editing an existing instruction
+              PlateSwipeButton(
+                  stringResource(R.string.RecipeListInstructionsScreen_Delete),
+                  modifier = Modifier.testTag(DELETE_BUTTON).weight(1f),
+                  onClick = { isDeleting = true },
+                  backgroundColor = MaterialTheme.colorScheme.error,
+                  contentColor = MaterialTheme.colorScheme.onError)
+          }
+          // Save Button
+          PlateSwipeButton(
+              stringResource(R.string.save_label),
+              modifier = Modifier.testTag(SAVE_BUTTON_TAG).weight(1f),
+              onClick = {
+                  showError = stepDescription.isEmpty() // Set error if instructions are empty
+                  confirmAndAssignStep(
+                      stepDescription,
+                      stepTime,
+                      selectedIcon,
+                      createRecipeViewModel,
+                      onSuccess = {
+                          createRecipeViewModel.resetSelectedInstruction()
+                          navigationActions.navigateToPop(
+                              Screen.CREATE_RECIPE_LIST_INSTRUCTIONS,
+                              popUpTo = Screen.CREATE_RECIPE_LIST_INGREDIENTS,
+                              inclusive = false)
+                      })
+              })
+
+      }
+
+
 
         Spacer(modifier = Modifier.height(SPACE_BETWEEN_ELEMENTS.dp))
 
-        if (createRecipeViewModel.getSelectedInstruction() != null) {
-          // suppress button if editing an existing instruction
-          PlateSwipeButton(
-              stringResource(R.string.RecipeListInstructionsScreen_Delete),
-              modifier = Modifier.fillMaxWidth().testTag(DELETE_BUTTON),
-              onClick = { isDeleting = true },
-              backgroundColor = MaterialTheme.colorScheme.error,
-              contentColor = MaterialTheme.colorScheme.onError)
-        }
+
         if (isDeleting) {
           PlateSwipeAlertBox(
               popUpMessage = stringResource(R.string.u_sure_u_want_to_delete),

--- a/app/src/main/java/com/android/sample/ui/createRecipe/AddInstructionStepScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/AddInstructionStepScreen.kt
@@ -204,7 +204,10 @@ fun AddInstructionStepContent(
                   createRecipeViewModel,
                   onSuccess = {
                     createRecipeViewModel.resetSelectedInstruction()
-                    navigationActions.navigateTo(Screen.CREATE_RECIPE_LIST_INSTRUCTIONS)
+                    navigationActions.navigateToPop(
+                        Screen.CREATE_RECIPE_LIST_INSTRUCTIONS,
+                        popUpTo = Screen.CREATE_RECIPE_LIST_INGREDIENTS,
+                        inclusive = false)
                   })
             })
       }

--- a/app/src/main/java/com/android/sample/ui/createRecipe/ListIngredientScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/ListIngredientScreen.kt
@@ -202,8 +202,8 @@ private fun SaveButton(
               if (!displayErrorIngredientMessage.value) {
                 navigationActions.navigateTo(
                     if (createRecipeViewModel.getRecipeListOfInstructions().isEmpty())
-                    Screen.CREATE_RECIPE_ADD_INSTRUCTION
-                else Screen.CREATE_RECIPE_LIST_INSTRUCTIONS)
+                        Screen.CREATE_RECIPE_ADD_INSTRUCTION
+                    else Screen.CREATE_RECIPE_LIST_INSTRUCTIONS)
               }
             },
             modifier =

--- a/app/src/main/java/com/android/sample/ui/createRecipe/ListIngredientScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/ListIngredientScreen.kt
@@ -155,7 +155,10 @@ fun IngredientListScreen(
                             createRecipeViewModel.addIngredientAndMeasurement(
                                 ingredient.name, ingredient.quantity.toString())
                           }
-                          navigationActions.navigateTo(Screen.CREATE_RECIPE_ADD_INSTRUCTION)
+                          navigationActions.navigateTo(
+                              if (createRecipeViewModel.getRecipeListOfInstructions().isEmpty())
+                                  Screen.CREATE_RECIPE_ADD_INSTRUCTION
+                              else Screen.CREATE_RECIPE_LIST_INSTRUCTIONS)
                         },
                         modifier =
                             Modifier.width(BUTTON_WIDTH)

--- a/app/src/main/java/com/android/sample/ui/createRecipe/ListIngredientScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/ListIngredientScreen.kt
@@ -207,11 +207,9 @@ private fun handleIngredientList(
           ingredient.name, ingredient.quantity.toString())
     }
     navigationActions.navigateTo(
-
         if (createRecipeViewModel.getRecipeListOfInstructions().isEmpty())
             Screen.CREATE_RECIPE_ADD_INSTRUCTION
-        else Screen.CREATE_RECIPE_LIST_INSTRUCTIONS
-    )
+        else Screen.CREATE_RECIPE_LIST_INSTRUCTIONS)
   }
 }
 

--- a/app/src/main/java/com/android/sample/ui/createRecipe/RecipeListInstructionsScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/RecipeListInstructionsScreen.kt
@@ -53,6 +53,7 @@ import com.android.sample.resources.C.Dimension.CreateRecipeListInstructionsScre
 import com.android.sample.resources.C.Dimension.CreateRecipeListInstructionsScreen.ROW_SIZE
 import com.android.sample.resources.C.Tag.RECIPE_NAME_BASE_PADDING
 import com.android.sample.resources.C.Tag.SMALL_PADDING
+import com.android.sample.resources.C.TestTag.CreateRecipeListInstructionsScreen.ADD_INSTRUCTION_BUTTON
 import com.android.sample.resources.C.TestTag.CreateRecipeListInstructionsScreen.EDIT_INSTRUCTION_ICON
 import com.android.sample.resources.C.TestTag.CreateRecipeListInstructionsScreen.INSTRUCTION_LIST
 import com.android.sample.resources.C.TestTag.CreateRecipeListInstructionsScreen.INSTRUCTION_LIST_ITEM
@@ -119,13 +120,14 @@ fun RecipeListInstructionsContent(
 
       Icon(
           imageVector = Icons.Default.Add,
-          contentDescription = "Edit",
+          contentDescription = "Add",
           modifier =
               Modifier.size(ICON_SIZE.dp)
                   .clickable(
                       onClick = {
                         navigationActions.navigateTo(Screen.CREATE_RECIPE_ADD_INSTRUCTION)
-                      }),
+                      })
+                  .testTag(ADD_INSTRUCTION_BUTTON),
           tint = MaterialTheme.colorScheme.onPrimary)
     }
 

--- a/app/src/main/java/com/android/sample/ui/createRecipe/RecipeListInstructionsScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/RecipeListInstructionsScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ModeEdit
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -93,6 +94,7 @@ fun RecipeListInstructionsContent(
     modifier: Modifier,
     navigationActions: NavigationActions,
 ) {
+  val maxChars = 14
 
   Column(
       modifier = modifier.padding(RECIPE_NAME_BASE_PADDING).testTag(SCREEN_COLUMN),
@@ -102,12 +104,29 @@ fun RecipeListInstructionsContent(
         modifier = Modifier.height(BIG_PADDING.dp).testTag(RECIPE_LIST_INSTRUCTIONS_SCREEN_SPACER1))
 
     // This text represents the name of the recipe
-    Text(
-        modifier = Modifier.testTag(RECIPE_NAME_TEXT),
-        text = createRecipeViewModel.getRecipeName(),
-        style = MaterialTheme.typography.titleMedium,
-        color = MaterialTheme.colorScheme.onPrimary,
-    )
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+      Text(
+          modifier = Modifier.testTag(RECIPE_NAME_TEXT),
+          text =
+              if (createRecipeViewModel.getRecipeName().length > maxChars)
+                  createRecipeViewModel.getRecipeName().take(maxChars) + "..."
+              else createRecipeViewModel.getRecipeName(),
+          style = MaterialTheme.typography.titleMedium,
+          color = MaterialTheme.colorScheme.onPrimary,
+      )
+
+      Icon(
+          imageVector = Icons.Default.Add,
+          contentDescription = "Edit",
+          modifier =
+              Modifier.size(ICON_SIZE.dp)
+                  .clickable(
+                      onClick = {
+                        navigationActions.navigateTo(Screen.CREATE_RECIPE_ADD_INSTRUCTION)
+                      }),
+          tint = MaterialTheme.colorScheme.onPrimary)
+    }
+
     // This text represents the "Instructions" title"
     Text(
         modifier = Modifier.testTag(INSTRUCTION_TEXT),

--- a/app/src/main/java/com/android/sample/ui/createRecipe/RecipeListInstructionsScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/RecipeListInstructionsScreen.kt
@@ -1,5 +1,6 @@
 package com.android.sample.ui.createRecipe
 
+import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -32,6 +33,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -165,12 +167,22 @@ fun RecipeListInstructionsContent(
                 })
           }
         }
-
+    val context = LocalContext.current
     // Fixed button at the bottom
     PlateSwipeButton(
         text = stringResource(R.string.next_step),
         modifier = Modifier.align(Alignment.CenterHorizontally).testTag(NEXT_STEP_BUTTON),
-        onClick = { navigationActions.navigateTo(Screen.CREATE_RECIPE_ADD_IMAGE) },
+        onClick = {
+          if (createRecipeViewModel.getRecipeListOfInstructions().isNotEmpty()) {
+            navigationActions.navigateTo(Screen.CREATE_RECIPE_ADD_IMAGE)
+          } else {
+            Toast.makeText(
+                    context,
+                    context.getString(R.string.RecipeListInstruction_add_instruction_please),
+                    Toast.LENGTH_SHORT)
+                .show()
+          }
+        },
     )
   }
 }

--- a/app/src/main/java/com/android/sample/ui/createRecipe/RecipeListInstructionsScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/RecipeListInstructionsScreen.kt
@@ -53,7 +53,9 @@ import com.android.sample.resources.C.Dimension.CreateRecipeListInstructionsScre
 import com.android.sample.resources.C.Dimension.CreateRecipeListInstructionsScreen.ROW_SIZE
 import com.android.sample.resources.C.Tag.RECIPE_NAME_BASE_PADDING
 import com.android.sample.resources.C.Tag.SMALL_PADDING
+import com.android.sample.resources.C.TestTag.CreateRecipeListInstructionsScreen.ADD_ICON_DESCRIPTION
 import com.android.sample.resources.C.TestTag.CreateRecipeListInstructionsScreen.ADD_INSTRUCTION_BUTTON
+import com.android.sample.resources.C.TestTag.CreateRecipeListInstructionsScreen.EDIT_ICON_DESCRIPTION
 import com.android.sample.resources.C.TestTag.CreateRecipeListInstructionsScreen.EDIT_INSTRUCTION_ICON
 import com.android.sample.resources.C.TestTag.CreateRecipeListInstructionsScreen.INSTRUCTION_LIST
 import com.android.sample.resources.C.TestTag.CreateRecipeListInstructionsScreen.INSTRUCTION_LIST_ITEM
@@ -67,6 +69,7 @@ import com.android.sample.resources.C.TestTag.CreateRecipeListInstructionsScreen
 import com.android.sample.resources.C.TestTag.CreateRecipeListInstructionsScreen.RECIPE_LIST_ITEM_THUMBNAIL
 import com.android.sample.resources.C.TestTag.CreateRecipeListInstructionsScreen.RECIPE_NAME_TEXT
 import com.android.sample.resources.C.TestTag.CreateRecipeListInstructionsScreen.SCREEN_COLUMN
+import com.android.sample.resources.C.TestTag.CreateRecipeListInstructionsScreen.STEP_ICON_DESCRIPTION
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Route
 import com.android.sample.ui.navigation.Screen
@@ -120,7 +123,7 @@ fun RecipeListInstructionsContent(
 
       Icon(
           imageVector = Icons.Default.Add,
-          contentDescription = "Add",
+          contentDescription = ADD_ICON_DESCRIPTION,
           modifier =
               Modifier.size(ICON_SIZE.dp)
                   .clickable(
@@ -232,7 +235,7 @@ fun InstructionValue(
                     painter =
                         painterResource(
                             id = createRecipeViewModel.getRecipeInstruction(index).icon.iconResId),
-                    contentDescription = "Icon",
+                    contentDescription = STEP_ICON_DESCRIPTION,
                     modifier = Modifier.size(ICON_SIZE.dp).testTag(RECIPE_LIST_INSTRUCTION_ICON))
 
                 Column(modifier = Modifier.testTag(INSTRUCTION_TEXT_SPACE)) {
@@ -255,7 +258,7 @@ fun InstructionValue(
                 }
                 Icon(
                     imageVector = Icons.Default.ModeEdit,
-                    contentDescription = "Edit",
+                    contentDescription = EDIT_ICON_DESCRIPTION,
                     modifier = Modifier.size(ICON_SIZE.dp).testTag(EDIT_INSTRUCTION_ICON))
               }
         }

--- a/app/src/main/java/com/android/sample/ui/createRecipe/RecipeListInstructionsScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/RecipeListInstructionsScreen.kt
@@ -49,6 +49,7 @@ import com.android.sample.resources.C.Dimension.CreateRecipeListInstructionsScre
 import com.android.sample.resources.C.Dimension.CreateRecipeListInstructionsScreen.ICON_SIZE
 import com.android.sample.resources.C.Dimension.CreateRecipeListInstructionsScreen.MEDIUM_PADDING
 import com.android.sample.resources.C.Dimension.CreateRecipeListInstructionsScreen.REALLY_SMALL_PADDING
+import com.android.sample.resources.C.Dimension.CreateRecipeListInstructionsScreen.RECIPE_NAME_MAX_CHAR
 import com.android.sample.resources.C.Dimension.CreateRecipeListInstructionsScreen.ROW_SIZE
 import com.android.sample.resources.C.Tag.RECIPE_NAME_BASE_PADDING
 import com.android.sample.resources.C.Tag.SMALL_PADDING
@@ -96,7 +97,6 @@ fun RecipeListInstructionsContent(
     modifier: Modifier,
     navigationActions: NavigationActions,
 ) {
-  val maxChars = 14
 
   Column(
       modifier = modifier.padding(RECIPE_NAME_BASE_PADDING).testTag(SCREEN_COLUMN),
@@ -110,8 +110,8 @@ fun RecipeListInstructionsContent(
       Text(
           modifier = Modifier.testTag(RECIPE_NAME_TEXT),
           text =
-              if (createRecipeViewModel.getRecipeName().length > maxChars)
-                  createRecipeViewModel.getRecipeName().take(maxChars) + "..."
+              if (createRecipeViewModel.getRecipeName().length > RECIPE_NAME_MAX_CHAR)
+                  createRecipeViewModel.getRecipeName().take(RECIPE_NAME_MAX_CHAR) + "..."
               else createRecipeViewModel.getRecipeName(),
           style = MaterialTheme.typography.titleMedium,
           color = MaterialTheme.colorScheme.onPrimary,

--- a/app/src/main/java/com/android/sample/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/sample/ui/navigation/NavigationActions.kt
@@ -55,7 +55,6 @@ object Screen {
 
 data class TopLevelDestination(val route: String, val iconId: Int, val textId: String)
 
-// TODO: Find good icons for each Route
 object TopLevelDestinations {
   val SWIPE = TopLevelDestination(Route.SWIPE, R.drawable.mainpageicon, "Swipe")
   val FRIDGE = TopLevelDestination(Route.FRIDGE, R.drawable.fridgeicon, "Fridge")

--- a/app/src/main/java/com/android/sample/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/sample/ui/navigation/NavigationActions.kt
@@ -123,4 +123,20 @@ open class NavigationActions(
   open fun currentRoute(): String {
     return navController.currentDestination?.route ?: ""
   }
+
+  /**
+   * Navigate to the specified screen and clear the back stack up to the specified destination. This
+   * is useful when navigating to a new screen from the bottom navigation bar as we don't want to
+   * keep the previous screen in the back stack.
+   *
+   * @param screen The screen to navigate to
+   * @param popUpTo The destination to clear the back stack up to
+   * @param inclusive Whether to include the destination in the back stack
+   */
+  open fun navigateToPop(screen: String, popUpTo: String?, inclusive: Boolean = false) {
+    navController.navigate(screen) {
+      popUpTo?.let { popUpTo(it) { this.inclusive = inclusive } }
+      launchSingleTop = true
+    }
+  }
 }

--- a/app/src/main/java/com/android/sample/ui/utils/PlateSwipeAlertBox.kt
+++ b/app/src/main/java/com/android/sample/ui/utils/PlateSwipeAlertBox.kt
@@ -29,15 +29,18 @@ fun PlateSwipeAlertBox(
     dismissMessage: String,
     onDismiss: () -> Unit,
     containerColor: Color = MaterialTheme.colorScheme.onPrimaryContainer,
-    textColor: Color = MaterialTheme.colorScheme.onPrimary
+    textColor: Color = MaterialTheme.colorScheme.onPrimary,
+    modifierAlertBox: Modifier =
+        Modifier.fillMaxWidth()
+            .padding(PADDING.dp)
+            .shadow(elevation = POP_UP_ELEVATION.dp, clip = POP_UP_CLIP)
+            .testTag(CONFIRMATION_POP_UP),
+    modifierConfirmationButton: Modifier = Modifier.testTag(CONFIRMATION_BUTTON),
+    modifierDismissButton: Modifier = Modifier.testTag(CANCEL_BUTTON)
 ) {
   AlertDialog(
       onDismissRequest = onDismiss,
-      modifier =
-          Modifier.fillMaxWidth()
-              .padding(PADDING.dp)
-              .shadow(elevation = POP_UP_ELEVATION.dp, clip = POP_UP_CLIP)
-              .testTag(CONFIRMATION_POP_UP),
+      modifier = modifierAlertBox,
       title = {
         Text(
             text = popUpMessage,
@@ -46,13 +49,13 @@ fun PlateSwipeAlertBox(
             color = textColor)
       },
       confirmButton = {
-        TextButton(onClick = onConfirm, modifier = Modifier.testTag(CONFIRMATION_BUTTON)) {
+        TextButton(onClick = onConfirm, modifier = modifierConfirmationButton) {
           Text(
               text = confirmMessage, style = MaterialTheme.typography.titleSmall, color = textColor)
         }
       },
       dismissButton = {
-        TextButton(onClick = onDismiss, modifier = Modifier.testTag(CANCEL_BUTTON)) {
+        TextButton(onClick = onDismiss, modifier = modifierDismissButton) {
           Text(
               text = dismissMessage, style = MaterialTheme.typography.titleSmall, color = textColor)
         }

--- a/app/src/main/java/com/android/sample/ui/utils/PlateSwipeAlertBox.kt
+++ b/app/src/main/java/com/android/sample/ui/utils/PlateSwipeAlertBox.kt
@@ -1,0 +1,61 @@
+package com.android.sample.ui.utils
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.android.sample.resources.C.Dimension.RecipeList.POP_UP_CLIP
+import com.android.sample.resources.C.Dimension.RecipeList.POP_UP_DESCRIPTION_FONT_SIZE
+import com.android.sample.resources.C.Dimension.RecipeList.POP_UP_ELEVATION
+import com.android.sample.resources.C.Tag.PADDING
+import com.android.sample.resources.C.TestTag.RecipeList.CANCEL_BUTTON
+import com.android.sample.resources.C.TestTag.RecipeList.CONFIRMATION_BUTTON
+import com.android.sample.resources.C.TestTag.RecipeList.CONFIRMATION_POP_UP
+
+@Composable
+fun PlateSwipeAlertBox(
+    popUpMessage: String,
+    confirmMessage: String,
+    onConfirm: () -> Unit,
+    dismissMessage: String,
+    onDismiss: () -> Unit,
+    containerColor: Color = MaterialTheme.colorScheme.onPrimaryContainer,
+    textColor: Color = MaterialTheme.colorScheme.onPrimary
+) {
+  AlertDialog(
+      onDismissRequest = onDismiss,
+      modifier =
+          Modifier.fillMaxWidth()
+              .padding(PADDING.dp)
+              .shadow(elevation = POP_UP_ELEVATION.dp, clip = POP_UP_CLIP)
+              .testTag(CONFIRMATION_POP_UP),
+      title = {
+        Text(
+            text = popUpMessage,
+            style = MaterialTheme.typography.titleSmall,
+            fontSize = POP_UP_DESCRIPTION_FONT_SIZE.sp,
+            color = textColor)
+      },
+      confirmButton = {
+        TextButton(onClick = onConfirm, modifier = Modifier.testTag(CONFIRMATION_BUTTON)) {
+          Text(
+              text = confirmMessage, style = MaterialTheme.typography.titleSmall, color = textColor)
+        }
+      },
+      dismissButton = {
+        TextButton(onClick = onDismiss, modifier = Modifier.testTag(CANCEL_BUTTON)) {
+          Text(
+              text = dismissMessage, style = MaterialTheme.typography.titleSmall, color = textColor)
+        }
+      },
+      containerColor = containerColor)
+}

--- a/app/src/main/java/com/android/sample/ui/utils/PlateSwipeAlertBox.kt
+++ b/app/src/main/java/com/android/sample/ui/utils/PlateSwipeAlertBox.kt
@@ -30,17 +30,14 @@ fun PlateSwipeAlertBox(
     onDismiss: () -> Unit,
     containerColor: Color = MaterialTheme.colorScheme.onPrimaryContainer,
     textColor: Color = MaterialTheme.colorScheme.onPrimary,
-    modifierAlertBox: Modifier =
-        Modifier.fillMaxWidth()
-            .padding(PADDING.dp)
-            .shadow(elevation = POP_UP_ELEVATION.dp, clip = POP_UP_CLIP)
-            .testTag(CONFIRMATION_POP_UP),
-    modifierConfirmationButton: Modifier = Modifier.testTag(CONFIRMATION_BUTTON),
-    modifierDismissButton: Modifier = Modifier.testTag(CANCEL_BUTTON)
 ) {
   AlertDialog(
       onDismissRequest = onDismiss,
-      modifier = modifierAlertBox,
+      modifier =
+          Modifier.fillMaxWidth()
+              .padding(PADDING.dp)
+              .shadow(elevation = POP_UP_ELEVATION.dp, clip = POP_UP_CLIP)
+              .testTag(CONFIRMATION_POP_UP),
       title = {
         Text(
             text = popUpMessage,
@@ -49,13 +46,13 @@ fun PlateSwipeAlertBox(
             color = textColor)
       },
       confirmButton = {
-        TextButton(onClick = onConfirm, modifier = modifierConfirmationButton) {
+        TextButton(onClick = onConfirm, modifier = Modifier.testTag(CONFIRMATION_BUTTON)) {
           Text(
               text = confirmMessage, style = MaterialTheme.typography.titleSmall, color = textColor)
         }
       },
       dismissButton = {
-        TextButton(onClick = onDismiss, modifier = modifierDismissButton) {
+        TextButton(onClick = onDismiss, modifier = Modifier.testTag(CANCEL_BUTTON)) {
           Text(
               text = dismissMessage, style = MaterialTheme.typography.titleSmall, color = textColor)
         }

--- a/app/src/main/java/com/android/sample/ui/utils/PlateSwipeButton.kt
+++ b/app/src/main/java/com/android/sample/ui/utils/PlateSwipeButton.kt
@@ -10,7 +10,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.android.sample.resources.C
 import com.android.sample.resources.C.Dimension.CreateRecipeListInstructionsScreen.ROUNDED_CORNER_SHAPE
@@ -28,21 +30,23 @@ fun PlateSwipeButton(
     text: String,
     modifier: Modifier,
     onClick: () -> Unit,
+    width: Dp = C.Tag.PlateSwipeButton.BUTTON_WIDTH,
+    height: Dp = C.Tag.PlateSwipeButton.BUTTON_HEIGHT,
+    backgroundColor: Color = MaterialTheme.colorScheme.primary,
+    contentColor: Color = MaterialTheme.colorScheme.onPrimary,
+    roundedCornerShape: RoundedCornerShape = RoundedCornerShape(ROUNDED_CORNER_SHAPE.dp)
 ) {
   Button(
       onClick = { onClick() },
       modifier =
           modifier
-              .width(C.Tag.PlateSwipeButton.BUTTON_WIDTH)
-              .height(C.Tag.PlateSwipeButton.BUTTON_HEIGHT)
-              .background(
-                  color = MaterialTheme.colorScheme.primary,
-                  shape = RoundedCornerShape(size = ROUNDED_CORNER_SHAPE.dp)),
+              .width(width)
+              .height(height)
+              .background(color = backgroundColor, shape = roundedCornerShape),
       colors =
           ButtonDefaults.buttonColors(
-              MaterialTheme.colorScheme.primary,
-              contentColor = MaterialTheme.colorScheme.onPrimary),
-      shape = RoundedCornerShape(ROUNDED_CORNER_SHAPE.dp)) {
+              containerColor = backgroundColor, contentColor = contentColor),
+      shape = roundedCornerShape) {
         Text(text = text, textAlign = TextAlign.Center)
       }
 }

--- a/app/src/main/java/com/android/sample/ui/utils/PlateSwipeButton.kt
+++ b/app/src/main/java/com/android/sample/ui/utils/PlateSwipeButton.kt
@@ -34,7 +34,6 @@ fun PlateSwipeButton(
     height: Dp = C.Tag.PlateSwipeButton.BUTTON_HEIGHT,
     backgroundColor: Color = MaterialTheme.colorScheme.primary,
     contentColor: Color = MaterialTheme.colorScheme.onPrimary,
-    roundedCornerShape: RoundedCornerShape = RoundedCornerShape(ROUNDED_CORNER_SHAPE.dp)
 ) {
   Button(
       onClick = { onClick() },
@@ -42,11 +41,12 @@ fun PlateSwipeButton(
           modifier
               .width(width)
               .height(height)
-              .background(color = backgroundColor, shape = roundedCornerShape),
+              .background(
+                  color = backgroundColor, shape = RoundedCornerShape(ROUNDED_CORNER_SHAPE.dp)),
       colors =
           ButtonDefaults.buttonColors(
               containerColor = backgroundColor, contentColor = contentColor),
-      shape = roundedCornerShape) {
+      shape = RoundedCornerShape(ROUNDED_CORNER_SHAPE.dp)) {
         Text(text = text, textAlign = TextAlign.Center)
       }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,6 +99,7 @@
     <string name="RecipeListInstructionsScreen_Instructions">Instructions</string>
     <string name="RecipeListInstructionsScreen_Step">Step</string>
     <string name="RecipeListInstructionsScreen_Minutes">min</string>
+    <string name="RecipeListInstructionsScreen_Delete">Delete</string>
     <string name="image_failed_to_load">Image failed to load</string>
 
     //RecipeListIngredientsScreen

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,6 +101,7 @@
     <string name="RecipeListInstructionsScreen_Minutes">min</string>
     <string name="RecipeListInstructionsScreen_Delete">Delete</string>
     <string name="image_failed_to_load">Image failed to load</string>
+    <string name="RecipeListInstruction_add_instruction_please">Please add at least one instruction</string>
 
     //RecipeListIngredientsScreen
     <string name="scanner_instruction">Scanner Icon</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,4 +122,9 @@
     <string name="pop_up_confirm_removal_liked_recipe">Yes</string>>
     <string name="pop_up_confirm_cancel_removal_liked_recipe">No</string>
 
+    //AddInstructionStepScreen
+    <string name = "u_sure_u_want_to_delete">Are you sure you want to delete this step?</string>
+    <string name = "delete">Delete</string>
+    <string name="cancel">Cancel</string>
+
 </resources>


### PR DESCRIPTION
# Add and Delete instruction button
## What has been changed?
### `RecipeListInstructionsScreen`
In the `RecipeListInstructionsScreen`, a new "Add Instruction" button has been introduced, allowing users to add instructions dynamically. By clicking this button, users are redirected to the `AddInstructionStepScreen`, where they can specify the time, description, and icon for the new instruction.


https://github.com/user-attachments/assets/abfc8b04-2df3-45a4-8543-763d152d49bb




Some little bugs were also patched:
* Name of the recipe was too long so it displayed all over the screen in `RecipeListInstructionsScreen`

### `AddInstructionStepScreen`
On the `AddInstructionStepScreen`, a delete button has been added to enable users to remove an instruction during the editing process. This addition enhances the overall flexibility of the feature. Once an instruction is created, users can now seamlessly modify or delete it, improving the user experience.

https://github.com/user-attachments/assets/327f192c-9672-4d14-abb3-8f47c4acb8bb

The choice of displaying the button one near the other was due to the fact that on a small display, if we decided to display one beneath the other, the bottom button could not be seen. Thus not enabling the user to delete an instruction.

### `PlateSwipeAlertBox`
A reusable alert box component, `PlateSwipeAlertBox`, has been implemented in the `ui/utils` folder. This component ensures consistent alert messaging across the app and allows for customization of colors and text. The design of the alert box is both functional and adaptable, offering developers flexibility while maintaining a unified look and feel for the application.
```kotlin
fun PlateSwipeAlertBox(
    popUpMessage: String,
    confirmMessage: String,
    onConfirm: () -> Unit,
    dismissMessage: String,
    onDismiss: () -> Unit,
    containerColor: Color = MaterialTheme.colorScheme.onPrimaryContainer,
    textColor: Color = MaterialTheme.colorScheme.onPrimary,
)

```

### Navigation between screens in` Create Recipe` Flow
The navigation had this problem of getting from the `IngredientList` screen to the `AddInstruction` screen which we don't want if the user already created some `Instructions`. So a method was introduced to skip this screen and to also pop this screen from the backstack which will enable a smooth navigation through the Create Recipe procedure.

```kotlin

open fun navigateToPop(screen: String, popUpTo: String?, inclusive: Boolean = false)

```

https://github.com/user-attachments/assets/52995cb1-7367-4c9b-b619-3e8d38191792




## Why was this change made?
This change was made in order to enable the possibility to the user to add and delete an `Instruction` in the user flow of the `Create Recipe` feature.

## Checklist
- [x] Tests added.
    * `AddInstructionStepContentTest`
    * `PlateSwipeAlertBoxTest`
    * `RecipeListInstructionsScreenTest`
- [x] Documentation updated.
- [x] All CI checks passed with > 80% line coverage on `SonarCloud`.
- [x] Linked issue/feature (if applicable): #231 
