### PR TITLE
fix: handle blank instruction validation in AddInstructionStepScreen

### DIFF
--- a/app/src/androidTest/java/com/android/sample/createRecipe/AddInstructionStepContentTest.kt
+++ b/app/src/androidTest/java/com/android/sample/createRecipe/AddInstructionStepContentTest.kt
@@ -130,4 +130,23 @@ class AddInstructionStepScreenTest {
     // Verify time and category were updated with the new values
     verify { createRecipeViewModel.addRecipeInstruction(any()) }
   }
+
+  /**
+   * Verifies that an error message is displayed when attempting to save with a blank instruction.
+   */
+  @Test
+  fun addInstructionStepScreen_saveButtonShowsErrorIfInstructionBlank() {
+    composeTestRule.setContent {
+      AddInstructionStepScreen(
+          navigationActions = navigationActions, createRecipeViewModel = createRecipeViewModel)
+    }
+
+    // Input a blank instruction
+    composeTestRule.onNodeWithTag("InstructionInput").performTextInput("   ")
+    composeTestRule.onNodeWithTag(SAVE_BUTTON_TAG).performClick()
+    composeTestRule.waitForIdle()
+
+    // Verify that the error message is displayed
+    composeTestRule.onNodeWithTag("InstructionError").assertIsDisplayed()
+  }
 }

--- a/app/src/main/java/com/android/sample/ui/createRecipe/AddInstructionStepScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/AddInstructionStepScreen.kt
@@ -196,16 +196,18 @@ fun AddInstructionStepContent(
             stringResource(R.string.save_label),
             modifier = Modifier.fillMaxWidth().testTag(SAVE_BUTTON_TAG),
             onClick = {
-              showError = stepDescription.isEmpty() // Set error if instructions are empty
-              confirmAndAssignStep(
-                  stepDescription,
-                  stepTime,
-                  selectedIcon,
-                  createRecipeViewModel,
-                  onSuccess = {
-                    createRecipeViewModel.resetSelectedInstruction()
-                    navigationActions.navigateTo(Screen.CREATE_RECIPE_LIST_INSTRUCTIONS)
-                  })
+              showError = stepDescription.isBlank() // Set error if instructions are blank
+              if (!showError) {
+                confirmAndAssignStep(
+                    stepDescription,
+                    stepTime,
+                    selectedIcon,
+                    createRecipeViewModel,
+                    onSuccess = {
+                      createRecipeViewModel.resetSelectedInstruction()
+                      navigationActions.navigateTo(Screen.CREATE_RECIPE_LIST_INSTRUCTIONS)
+                    })
+              }
             })
       }
 }
@@ -226,7 +228,7 @@ fun <T> defaultValues(defaultValue: T, selectedInstruction: Int?, onSuccess: (In
  * @return True if the error should be shown, false otherwise.
  */
 fun verifyStepDescription(showError: Boolean, stepDescription: String): Boolean {
-  return showError && stepDescription.isEmpty()
+  return showError && stepDescription.isBlank()
 }
 
 /**

--- a/app/src/main/java/com/android/sample/ui/createRecipe/AddInstructionStepScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/AddInstructionStepScreen.kt
@@ -196,20 +196,49 @@ fun AddInstructionStepContent(
             stringResource(R.string.save_label),
             modifier = Modifier.fillMaxWidth().testTag(SAVE_BUTTON_TAG),
             onClick = {
-              showError = stepDescription.isBlank() // Set error if instructions are blank
-              if (!showError) {
-                confirmAndAssignStep(
-                    stepDescription,
-                    stepTime,
-                    selectedIcon,
-                    createRecipeViewModel,
-                    onSuccess = {
-                      createRecipeViewModel.resetSelectedInstruction()
-                      navigationActions.navigateTo(Screen.CREATE_RECIPE_LIST_INSTRUCTIONS)
-                    })
-              }
+              processValidInstruction(
+                  stepDescription = stepDescription,
+                  stepTime = stepTime,
+                  selectedIcon = selectedIcon,
+                  createRecipeViewModel = createRecipeViewModel,
+                  navigationActions = navigationActions,
+                  setShowError = { showError = it })
             })
       }
+}
+
+/**
+ * Processes a recipe step by validating the instruction and, if valid, assigning the provided
+ * details to the recipe. Navigates to the instruction list screen upon success.
+ *
+ * @param stepDescription The description of the recipe step.
+ * @param stepTime The time required for the step (optional).
+ * @param selectedIcon The selected icon for the step (optional).
+ * @param createRecipeViewModel The ViewModel managing the recipe creation process.
+ * @param navigationActions The navigation actions for moving between screens.
+ * @param setShowError A lambda to update the error state in the UI.
+ */
+private fun processValidInstruction(
+    stepDescription: String,
+    stepTime: String?,
+    selectedIcon: IconType?,
+    createRecipeViewModel: CreateRecipeViewModel,
+    navigationActions: NavigationActions,
+    setShowError: (Boolean) -> Unit
+) {
+  if (stepDescription.isBlank()) {
+    setShowError(true) // Trigger the error state if the instruction is blank
+  } else {
+    confirmAndAssignStep(
+        stepDescription,
+        stepTime,
+        selectedIcon,
+        createRecipeViewModel,
+        onSuccess = {
+          createRecipeViewModel.resetSelectedInstruction()
+          navigationActions.navigateTo(Screen.CREATE_RECIPE_LIST_INSTRUCTIONS)
+        })
+  }
 }
 
 fun <T> defaultValues(defaultValue: T, selectedInstruction: Int?, onSuccess: (Int) -> T): T {


### PR DESCRIPTION

# Description

-  **What has been changed?**  
  Added validation in `AddInstructionStepScreen` to handle blank (whitespace-only) instructions by displaying an error message and preventing the app from crashing. Updated the test suite to include a specific case for this validation.  

```kotlin
// Updated validation in AddInstructionStepScreen
fun verifyStepDescription(showError: Boolean, stepDescription: String): Boolean {
    return showError && stepDescription.isBlank() // Now handles both empty and blank cases
}

// Save button logic updated to trigger the validation
PlateSwipeButton(
    ...
    onClick = {
        showError = stepDescription.isBlank() // Validate for blank instruction
        if (!showError) {
            confirmAndAssignStep(...)
        }
    }
)
```

- **Why was this change made?**  
  To ensure that blank instructions are treated as invalid, improving the robustness of input validation and preventing the app from crashing when users attempt to save an invalid instruction.

---

# Checklist

- [x] Tests added.  
  A new test case was added to verify the updated validation logic:

```kotlin
@Test
fun addInstructionStepScreen_saveButtonShowsErrorIfInstructionBlank() {
    composeTestRule.setContent {
        AddInstructionStepScreen(
            navigationActions = navigationActions, createRecipeViewModel = createRecipeViewModel
        )
    }

    // Input a blank instruction
    composeTestRule.onNodeWithTag("InstructionInput").performTextInput("   ")
    composeTestRule.onNodeWithTag(SAVE_BUTTON_TAG).performClick()
    composeTestRule.waitForIdle()

    // Verify that the error message is displayed
    composeTestRule.onNodeWithTag("InstructionError").assertIsDisplayed()
}
```

- [ ] Documentation updated.  
- [x] All CI checks passed.  
- [x] Linked issue/feature: #232  

