### PR TITLE
Feature/total time screen

### DIFF
--- a/app/src/androidTest/java/com/android/sample/createRecipe/RecipeListInstructionsScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/createRecipe/RecipeListInstructionsScreenTest.kt
@@ -77,6 +77,6 @@ class RecipeListInstructionsScreenTest {
     composeTestRule.onNodeWithTag(NEXT_STEP_BUTTON).assertIsDisplayed().performClick()
 
     // Verify that the navigateTo function was called with the correct parameter
-    verify { navigationActions.navigateTo(Screen.CREATE_RECIPE_ADD_IMAGE) }
+    verify { navigationActions.navigateTo(Screen.CREATE_RECIPE_TIME_PICKER) }
   }
 }

--- a/app/src/androidTest/java/com/android/sample/createRecipe/TimePickerScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/createRecipe/TimePickerScreenTest.kt
@@ -8,7 +8,9 @@ import androidx.compose.ui.test.performClick
 import com.android.sample.model.image.ImageRepositoryFirebase
 import com.android.sample.model.recipe.CreateRecipeViewModel
 import com.android.sample.model.recipe.FirestoreRecipesRepository
+import com.android.sample.resources.C.TestTag.TimePicker.HOURS_LABEL
 import com.android.sample.resources.C.TestTag.TimePicker.HOUR_PICKER
+import com.android.sample.resources.C.TestTag.TimePicker.MINUTES_LABEL
 import com.android.sample.resources.C.TestTag.TimePicker.MINUTE_PICKER
 import com.android.sample.resources.C.TestTag.TimePicker.NEXT_BUTTON
 import com.android.sample.resources.C.TestTag.TimePicker.TIME_PICKER_DESCRIPTION
@@ -56,6 +58,12 @@ class TimePickerScreenTest {
 
     // Verify description is displayed
     composeTestRule.onNodeWithTag(TIME_PICKER_DESCRIPTION).assertExists().assertIsDisplayed()
+
+    // Verify "Hours" label is displayed
+    composeTestRule.onNodeWithTag(HOURS_LABEL).assertExists().assertIsDisplayed()
+
+    // Verify "Minutes" label is displayed
+    composeTestRule.onNodeWithTag(MINUTES_LABEL).assertExists().assertIsDisplayed()
 
     // Verify hour and minute pickers are displayed
     composeTestRule.onNodeWithTag(HOUR_PICKER).assertExists().assertIsDisplayed()

--- a/app/src/androidTest/java/com/android/sample/createRecipe/TimePickerScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/createRecipe/TimePickerScreenTest.kt
@@ -148,4 +148,41 @@ class TimePickerScreenTest {
     // Verify that the minute picker starts at 0
     composeTestRule.onNodeWithTag(MINUTE_PICKER).assertExists().assertContentDescriptionEquals("0")
   }
+
+  @Test
+  fun testGetRecipeTimeCalledOnce() {
+    // Mock the initial recipe time
+    every { createRecipeViewModel.getRecipeTime() } returns "125"
+
+    composeTestRule.setContent {
+      TimePickerScreen(
+          navigationActions = mockNavigationActions, createRecipeViewModel = createRecipeViewModel)
+    }
+
+    // Verify that getRecipeTime was called exactly once
+    verify(exactly = 1) { createRecipeViewModel.getRecipeTime() }
+  }
+
+  @Test
+  fun testPickerStateUpdatesIndependently() {
+    every { createRecipeViewModel.getRecipeTime() } returns "125"
+
+    composeTestRule.setContent {
+      TimePickerScreen(
+          navigationActions = mockNavigationActions, createRecipeViewModel = createRecipeViewModel)
+    }
+
+    // Simulate interacting with the hour picker
+    composeTestRule.onNodeWithTag(HOUR_PICKER).performClick()
+    composeTestRule
+        .onNodeWithTag(HOUR_PICKER)
+        .assertContentDescriptionEquals("2") // Initial value: 2
+
+    // Simulate changing the hour
+    composeTestRule.onNodeWithTag(HOUR_PICKER).performClick()
+    // Ensure minute picker value remains unchanged
+    composeTestRule
+        .onNodeWithTag(MINUTE_PICKER)
+        .assertContentDescriptionEquals("5") // Initial value: 5
+  }
 }

--- a/app/src/androidTest/java/com/android/sample/createRecipe/TimePickerScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/createRecipe/TimePickerScreenTest.kt
@@ -1,0 +1,143 @@
+package com.android.sample.createRecipe
+
+import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.android.sample.model.image.ImageRepositoryFirebase
+import com.android.sample.model.recipe.CreateRecipeViewModel
+import com.android.sample.model.recipe.FirestoreRecipesRepository
+import com.android.sample.resources.C.TestTag.TimePicker.HOUR_PICKER
+import com.android.sample.resources.C.TestTag.TimePicker.MINUTE_PICKER
+import com.android.sample.resources.C.TestTag.TimePicker.NEXT_BUTTON
+import com.android.sample.resources.C.TestTag.TimePicker.TIME_PICKER_DESCRIPTION
+import com.android.sample.resources.C.TestTag.TimePicker.TIME_PICKER_TITLE
+import com.android.sample.ui.createRecipe.TimePickerScreen
+import com.android.sample.ui.navigation.NavigationActions
+import com.android.sample.ui.navigation.Screen
+import com.google.firebase.firestore.FirebaseFirestore
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class TimePickerScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private lateinit var mockNavigationActions: NavigationActions
+  private lateinit var createRecipeViewModel: CreateRecipeViewModel
+  private lateinit var repoImg: ImageRepositoryFirebase
+
+  @Before
+  fun setUp() = runTest {
+    mockNavigationActions = mockk(relaxed = true)
+
+    val firestore = mockk<FirebaseFirestore>(relaxed = true)
+    val repository = FirestoreRecipesRepository(firestore)
+    repoImg = mockk(relaxed = true)
+    createRecipeViewModel = spyk(CreateRecipeViewModel(repository, repoImg))
+  }
+
+  @Test
+  fun testTimePickerScreenComponentsAreDisplayed() {
+    composeTestRule.setContent {
+      TimePickerScreen(
+          navigationActions = mockNavigationActions, createRecipeViewModel = createRecipeViewModel)
+    }
+
+    // Verify title is displayed
+    composeTestRule.onNodeWithTag(TIME_PICKER_TITLE).assertExists().assertIsDisplayed()
+
+    // Verify description is displayed
+    composeTestRule.onNodeWithTag(TIME_PICKER_DESCRIPTION).assertExists().assertIsDisplayed()
+
+    // Verify hour and minute pickers are displayed
+    composeTestRule.onNodeWithTag(HOUR_PICKER).assertExists().assertIsDisplayed()
+    composeTestRule.onNodeWithTag(MINUTE_PICKER).assertExists().assertIsDisplayed()
+
+    // Verify Next button is displayed
+    composeTestRule.onNodeWithTag(NEXT_BUTTON).assertExists().assertIsDisplayed()
+  }
+
+  @Test
+  fun testNextStepButtonNavigatesToNextScreen() {
+    composeTestRule.setContent {
+      TimePickerScreen(
+          navigationActions = mockNavigationActions, createRecipeViewModel = createRecipeViewModel)
+    }
+
+    // Click the "Next Step" button
+    composeTestRule.onNodeWithTag(NEXT_BUTTON).assertExists().performClick()
+
+    // Verify navigation to the next screen
+    verify { mockNavigationActions.navigateTo(Screen.CREATE_RECIPE_ADD_IMAGE) }
+  }
+
+  @Test
+  fun testTimePickerUpdatesRecipeTimeInViewModel() {
+    composeTestRule.setContent {
+      TimePickerScreen(
+          navigationActions = mockNavigationActions, createRecipeViewModel = createRecipeViewModel)
+    }
+
+    // Simulate selecting hours and minutes
+    composeTestRule.onNodeWithTag(HOUR_PICKER).performClick()
+    composeTestRule.onNodeWithTag(MINUTE_PICKER).performClick()
+
+    // Click "Next Step" to trigger time update
+    composeTestRule.onNodeWithTag(NEXT_BUTTON).assertExists().performClick()
+
+    // Verify that the recipe time in the ViewModel was updated
+    verify {
+      createRecipeViewModel.updateRecipeTime(
+          match { time ->
+            (time.toIntOrNull() ?: 0) >= 0 // Ensure it's set to a valid integer time
+          })
+    }
+  }
+
+  @Test
+  fun testWheelTimePickerDisplaysInitialValues() {
+    // Mock the initial recipe time (e.g., 125 minutes)
+    every { createRecipeViewModel.getRecipeTime() } returns "125"
+
+    composeTestRule.setContent {
+      TimePickerScreen(
+          navigationActions = mockNavigationActions, createRecipeViewModel = createRecipeViewModel)
+    }
+
+    // Verify the hour picker displays the correct initial hour (2)
+    composeTestRule
+        .onNodeWithTag(HOUR_PICKER)
+        .assertExists()
+        .assertContentDescriptionEquals("2") // Use content description instead of text
+
+    // Verify the minute picker displays the correct initial minute (5)
+    composeTestRule
+        .onNodeWithTag(MINUTE_PICKER)
+        .assertExists()
+        .assertContentDescriptionEquals("5") // Use content description instead of text
+  }
+
+  @Test
+  fun testInvalidStateHandling() {
+    every { createRecipeViewModel.getRecipeTime() } returns null // Simulate missing time
+
+    composeTestRule.setContent {
+      TimePickerScreen(
+          navigationActions = mockNavigationActions, createRecipeViewModel = createRecipeViewModel)
+    }
+
+    // Verify that the hour picker starts at 0
+    composeTestRule.onNodeWithTag(HOUR_PICKER).assertExists().assertContentDescriptionEquals("0")
+
+    // Verify that the minute picker starts at 0
+    composeTestRule.onNodeWithTag(MINUTE_PICKER).assertExists().assertContentDescriptionEquals("0")
+  }
+}

--- a/app/src/androidTest/java/com/android/sample/e2e/End2EndTest.kt
+++ b/app/src/androidTest/java/com/android/sample/e2e/End2EndTest.kt
@@ -55,6 +55,11 @@ import com.android.sample.resources.C.TestTag.RecipeList.RECIPE_FAVORITE_ICON_TE
 import com.android.sample.resources.C.TestTag.RecipeList.RECIPE_TITLE_TEST_TAG
 import com.android.sample.resources.C.TestTag.RecipeOverview.RECIPE_TITLE
 import com.android.sample.resources.C.TestTag.SwipePage.DRAGGABLE_ITEM
+import com.android.sample.resources.C.TestTag.TimePicker.HOUR_PICKER
+import com.android.sample.resources.C.TestTag.TimePicker.MINUTE_PICKER
+import com.android.sample.resources.C.TestTag.TimePicker.NEXT_BUTTON
+import com.android.sample.resources.C.TestTag.TimePicker.TIME_PICKER_DESCRIPTION
+import com.android.sample.resources.C.TestTag.TimePicker.TIME_PICKER_TITLE
 import com.android.sample.resources.C.TestTag.Utils.BACK_ARROW_ICON
 import com.android.sample.ui.account.AccountScreen
 import com.android.sample.ui.camera.CameraScanCodeBarScreen
@@ -68,6 +73,7 @@ import com.android.sample.ui.createRecipe.RecipeAddImageScreen
 import com.android.sample.ui.createRecipe.RecipeIngredientsScreen
 import com.android.sample.ui.createRecipe.RecipeInstructionsScreen
 import com.android.sample.ui.createRecipe.RecipeListInstructionsScreen
+import com.android.sample.ui.createRecipe.TimePickerScreen
 import com.android.sample.ui.filter.FilterPage
 import com.android.sample.ui.fridge.FridgeScreen
 import com.android.sample.ui.navigation.NavigationActions
@@ -427,6 +433,27 @@ class EndToEndTest {
         .performClick()
     composeTestRule.waitForIdle()
 
+    // Time Picker -------------------------------------------------------
+
+    // Verify the time picker screen is displayed
+    composeTestRule
+        .onNodeWithTag(TIME_PICKER_TITLE)
+        .assertExists()
+        .assertTextEquals("Select Total Time")
+    composeTestRule
+        .onNodeWithTag(TIME_PICKER_DESCRIPTION)
+        .assertExists()
+        .assertTextEquals(
+            "Selecting the total time is optional, but it helps others understand how long your recipe will take.")
+
+    // Simulate selecting 2 hours and 30 minutes
+    composeTestRule.onNodeWithTag(HOUR_PICKER).performClick() // Simulate selecting 2 hours
+    composeTestRule.onNodeWithTag(MINUTE_PICKER).performClick() // Simulate selecting 30 minutes
+
+    // Click Next Step button
+    composeTestRule.onNodeWithTag(NEXT_BUTTON).performClick()
+    composeTestRule.waitForIdle()
+
     // image -------------------------------------------------------
 
     composeTestRule.onNodeWithTag(DISPLAY_IMAGE_DEFAULT).assertIsDisplayed()
@@ -509,6 +536,9 @@ class EndToEndTest {
         composable(Screen.CREATE_RECIPE_LIST_INSTRUCTIONS) {
           RecipeListInstructionsScreen(
               navigationActions = navigationActions, createRecipeViewModel = createRecipeViewModel)
+        }
+        composable(Screen.CREATE_RECIPE_TIME_PICKER) {
+          TimePickerScreen(navigationActions, createRecipeViewModel)
         }
         composable(Screen.CREATE_RECIPE_ADD_IMAGE) {
           RecipeAddImageScreen(navigationActions, createRecipeViewModel)

--- a/app/src/main/java/com/android/sample/MainActivity.kt
+++ b/app/src/main/java/com/android/sample/MainActivity.kt
@@ -36,6 +36,7 @@ import com.android.sample.ui.createRecipe.RecipeAddImageScreen
 import com.android.sample.ui.createRecipe.RecipeIngredientsScreen
 import com.android.sample.ui.createRecipe.RecipeInstructionsScreen
 import com.android.sample.ui.createRecipe.RecipeListInstructionsScreen
+import com.android.sample.ui.createRecipe.TimePickerScreen
 import com.android.sample.ui.filter.FilterPage
 import com.android.sample.ui.fridge.FridgeScreen
 import com.android.sample.ui.navigation.NavigationActions
@@ -136,6 +137,9 @@ fun PlateSwipeApp() {
       composable(Screen.CREATE_RECIPE_LIST_INSTRUCTIONS) {
         RecipeListInstructionsScreen(
             navigationActions = navigationActions, createRecipeViewModel = createRecipeViewModel)
+      }
+      composable(Screen.CREATE_RECIPE_TIME_PICKER) {
+        TimePickerScreen(navigationActions, createRecipeViewModel)
       }
       composable(Screen.CREATE_RECIPE_ADD_IMAGE) {
         RecipeAddImageScreen(navigationActions, createRecipeViewModel)

--- a/app/src/main/java/com/android/sample/resources/C.kt
+++ b/app/src/main/java/com/android/sample/resources/C.kt
@@ -342,6 +342,13 @@ object C {
 
     // Create Recipe Add Image
     const val ADD_IMAGE_STEP = 4
+
+    // TimePickerScreen
+    const val MINUTES_PER_HOUR = 60
+    const val HOUR_RANGE_START = 0
+    const val HOUR_RANGE_END = 23
+    const val MINUTE_RANGE_START = 0
+    const val MINUTE_RANGE_END = 59
   }
 
   object Values {

--- a/app/src/main/java/com/android/sample/resources/C.kt
+++ b/app/src/main/java/com/android/sample/resources/C.kt
@@ -792,6 +792,8 @@ object C {
       const val HOUR_PICKER = "HourPicker"
       const val MINUTE_PICKER = "MinutePicker"
       const val NEXT_BUTTON = "NextButton"
+      const val HOURS_LABEL = "HoursLabel"
+      const val MINUTES_LABEL = "MinutesLabel"
     }
   }
 }

--- a/app/src/main/java/com/android/sample/resources/C.kt
+++ b/app/src/main/java/com/android/sample/resources/C.kt
@@ -785,5 +785,13 @@ object C {
       // CategorySubtitle
       const val CATEGORY_SUBTITLE = "CategorySubtitle"
     }
+
+    object TimePicker {
+      const val TIME_PICKER_TITLE = "TimePickerTitle"
+      const val TIME_PICKER_DESCRIPTION = "TimePickerDescription"
+      const val HOUR_PICKER = "HourPicker"
+      const val MINUTE_PICKER = "MinutePicker"
+      const val NEXT_BUTTON = "NextButton"
+    }
   }
 }

--- a/app/src/main/java/com/android/sample/ui/createRecipe/RecipeListInstructionsScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/RecipeListInstructionsScreen.kt
@@ -179,7 +179,7 @@ fun RecipeListInstructionsContent(
         modifier = Modifier.align(Alignment.CenterHorizontally).testTag(NEXT_STEP_BUTTON),
         onClick = {
           if (createRecipeViewModel.getRecipeListOfInstructions().isNotEmpty()) {
-            navigationActions.navigateTo(Screen.CREATE_RECIPE_ADD_IMAGE)
+            navigationActions.navigateTo(Screen.CREATE_RECIPE_TIME_PICKER)
           } else {
             Toast.makeText(
                     context,

--- a/app/src/main/java/com/android/sample/ui/createRecipe/TimePickerScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/TimePickerScreen.kt
@@ -25,8 +25,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.android.sample.R
 import com.android.sample.model.recipe.CreateRecipeViewModel
+import com.android.sample.resources.C.Dimension.PADDING_16
 import com.android.sample.resources.C.Dimension.PADDING_32
-import com.android.sample.resources.C.Dimension.PADDING_8
+import com.android.sample.resources.C.Tag.HOUR_RANGE_END
+import com.android.sample.resources.C.Tag.HOUR_RANGE_START
+import com.android.sample.resources.C.Tag.MINUTES_PER_HOUR
+import com.android.sample.resources.C.Tag.MINUTE_RANGE_END
+import com.android.sample.resources.C.Tag.MINUTE_RANGE_START
 import com.android.sample.resources.C.Tag.THIRD_STEP_OF_THE_CREATION
 import com.android.sample.resources.C.TestTag.TimePicker.HOURS_LABEL
 import com.android.sample.resources.C.TestTag.TimePicker.HOUR_PICKER
@@ -75,23 +80,22 @@ fun TimePickerContent(
     navigationActions: NavigationActions,
     createRecipeViewModel: CreateRecipeViewModel
 ) {
-  val totalMinutes = createRecipeViewModel.getRecipeTime()?.toIntOrNull() ?: 0
-  val initialHours = totalMinutes / 60
-  val initialMinutes = totalMinutes % 60
+  val totalMinutes = remember { createRecipeViewModel.getRecipeTime()?.toIntOrNull() ?: 0 }
+  val initialHours = totalMinutes / MINUTES_PER_HOUR
+  val initialMinutes = totalMinutes % MINUTES_PER_HOUR
 
   val hours = remember { mutableIntStateOf(initialHours) }
   val minutes = remember { mutableIntStateOf(initialMinutes) }
 
-  Box(modifier = modifier.padding(PADDING_8.dp), contentAlignment = Alignment.TopCenter) {
+  Box(modifier = modifier.padding(PADDING_16.dp), contentAlignment = Alignment.TopCenter) {
     Column(
         modifier = Modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Top) {
-          Spacer(modifier = Modifier.weight(1f))
           // Progress Bar
           RecipeProgressBar(currentStep = currentStep)
 
-          Spacer(modifier = Modifier.weight(2f))
+          Spacer(modifier = Modifier.weight(1f))
 
           // Title
           Text(
@@ -134,7 +138,7 @@ fun TimePickerContent(
         text = stringResource(R.string.next_step),
         modifier = Modifier.align(Alignment.BottomCenter).testTag(NEXT_BUTTON),
         onClick = {
-          val totalTimeInMinutes = (hours.intValue * 60) + minutes.intValue
+          val totalTimeInMinutes = (hours.intValue * MINUTES_PER_HOUR) + minutes.intValue
           createRecipeViewModel.updateRecipeTime(totalTimeInMinutes.toString())
           navigationActions.navigateTo(Screen.CREATE_RECIPE_ADD_IMAGE)
         })
@@ -166,6 +170,8 @@ fun TimePickerContent(
  */
 @Composable
 fun WheelTimePicker(selectedHour: Int, selectedMinute: Int, onTimeSelected: (Int, Int) -> Unit) {
+  val currentHour = remember { mutableIntStateOf(selectedHour) }
+  val currentMinute = remember { mutableIntStateOf(selectedMinute) }
   Row(
       modifier = Modifier.fillMaxWidth().padding(horizontal = PADDING_32.dp),
       horizontalArrangement = Arrangement.SpaceAround,
@@ -181,9 +187,12 @@ fun WheelTimePicker(selectedHour: Int, selectedMinute: Int, onTimeSelected: (Int
 
           // Hour Picker
           NumberPickerComposable(
-              value = selectedHour,
-              range = 0..23,
-              onValueChange = { hour -> onTimeSelected(hour, selectedMinute) },
+              value = currentHour.intValue,
+              range = HOUR_RANGE_START..HOUR_RANGE_END,
+              onValueChange = { hour ->
+                currentHour.intValue = hour
+                onTimeSelected(hour, currentMinute.intValue)
+              },
               modifier = Modifier.testTag(HOUR_PICKER))
         }
 
@@ -205,9 +214,12 @@ fun WheelTimePicker(selectedHour: Int, selectedMinute: Int, onTimeSelected: (Int
 
           // Minute Picker
           NumberPickerComposable(
-              value = selectedMinute,
-              range = 0..59,
-              onValueChange = { minute -> onTimeSelected(selectedHour, minute) },
+              value = currentMinute.intValue,
+              range = MINUTE_RANGE_START..MINUTE_RANGE_END,
+              onValueChange = { minute ->
+                currentMinute.intValue = minute
+                onTimeSelected(currentHour.intValue, minute)
+              },
               modifier = Modifier.testTag(MINUTE_PICKER))
         }
       }

--- a/app/src/main/java/com/android/sample/ui/createRecipe/TimePickerScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/TimePickerScreen.kt
@@ -1,0 +1,240 @@
+package com.android.sample.ui.createRecipe
+
+import android.widget.NumberPicker
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.android.sample.R
+import com.android.sample.model.recipe.CreateRecipeViewModel
+import com.android.sample.resources.C.Dimension.PADDING_32
+import com.android.sample.resources.C.Dimension.PADDING_8
+import com.android.sample.resources.C.Tag.THIRD_STEP_OF_THE_CREATION
+import com.android.sample.resources.C.TestTag.TimePicker.HOUR_PICKER
+import com.android.sample.resources.C.TestTag.TimePicker.MINUTE_PICKER
+import com.android.sample.resources.C.TestTag.TimePicker.NEXT_BUTTON
+import com.android.sample.resources.C.TestTag.TimePicker.TIME_PICKER_DESCRIPTION
+import com.android.sample.resources.C.TestTag.TimePicker.TIME_PICKER_TITLE
+import com.android.sample.ui.navigation.NavigationActions
+import com.android.sample.ui.navigation.Route
+import com.android.sample.ui.navigation.Screen
+import com.android.sample.ui.theme.Typography
+import com.android.sample.ui.utils.PlateSwipeButton
+import com.android.sample.ui.utils.PlateSwipeScaffold
+
+@Composable
+fun TimePickerScreen(
+    navigationActions: NavigationActions,
+    createRecipeViewModel: CreateRecipeViewModel,
+) {
+  PlateSwipeScaffold(
+      navigationActions = navigationActions,
+      selectedItem = Route.CREATE_RECIPE,
+      showBackArrow = true,
+      content = { paddingValues ->
+        TimePickerContent(
+            currentStep = THIRD_STEP_OF_THE_CREATION,
+            navigationActions = navigationActions,
+            createRecipeViewModel = createRecipeViewModel,
+            modifier = Modifier.fillMaxSize().padding(paddingValues))
+      })
+}
+
+/**
+ * Composable function for selecting the total time for the recipe.
+ *
+ * @param modifier Modifier to be applied to the screen.
+ * @param currentStep The current step in the recipe creation process.
+ * @param navigationActions Actions for navigating between screens.
+ * @param createRecipeViewModel ViewModel for managing the recipe creation process.
+ */
+@Composable
+fun TimePickerContent(
+    modifier: Modifier = Modifier,
+    currentStep: Int,
+    navigationActions: NavigationActions,
+    createRecipeViewModel: CreateRecipeViewModel
+) {
+  val totalMinutes = createRecipeViewModel.getRecipeTime()?.toIntOrNull() ?: 0
+  val initialHours = totalMinutes / 60
+  val initialMinutes = totalMinutes % 60
+
+  val hours = remember { mutableStateOf(initialHours) }
+  val minutes = remember { mutableStateOf(initialMinutes) }
+
+  Box(modifier = modifier.padding(PADDING_8.dp), contentAlignment = Alignment.TopCenter) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Top) {
+          Spacer(modifier = Modifier.weight(1f))
+          // Progress Bar
+          RecipeProgressBar(currentStep = currentStep)
+
+          Spacer(modifier = Modifier.weight(2f))
+
+          // Title
+          Text(
+              text = stringResource(R.string.select_total_time),
+              style = Typography.displayLarge,
+              color = MaterialTheme.colorScheme.onPrimary,
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .padding(horizontal = PADDING_32.dp)
+                      .testTag(TIME_PICKER_TITLE),
+              textAlign = TextAlign.Center)
+
+          Spacer(modifier = Modifier.weight(1f))
+
+          // Description
+          Text(
+              text = stringResource(R.string.select_time_description),
+              style = MaterialTheme.typography.bodyMedium,
+              color = MaterialTheme.colorScheme.onPrimary,
+              modifier =
+                  Modifier.padding(horizontal = PADDING_32.dp).testTag(TIME_PICKER_DESCRIPTION),
+              textAlign = TextAlign.Center)
+
+          Spacer(modifier = Modifier.weight(3f))
+
+          // WheelTimePicker
+          WheelTimePicker(
+              selectedHour = hours.value,
+              selectedMinute = minutes.value,
+              onTimeSelected = { selectedHour, selectedMinute ->
+                hours.value = selectedHour
+                minutes.value = selectedMinute
+              })
+
+          Spacer(modifier = Modifier.weight(6f))
+        }
+
+    // Next Step Button
+    PlateSwipeButton(
+        text = stringResource(R.string.next_step),
+        modifier = Modifier.align(Alignment.BottomCenter).testTag(NEXT_BUTTON),
+        onClick = {
+          val totalTimeInMinutes = (hours.value * 60) + minutes.value
+          createRecipeViewModel.updateRecipeTime(totalTimeInMinutes.toString())
+          navigationActions.navigateTo(Screen.CREATE_RECIPE_ADD_IMAGE)
+        })
+  }
+}
+
+/**
+ * A composable function that displays a time picker with separate selectors for hours and minutes.
+ *
+ * @param selectedHour The currently selected hour (0-23).
+ * @param selectedMinute The currently selected minute (0-59).
+ * @param onTimeSelected A callback triggered when the user selects a new time. It provides the
+ *   selected hour and minute as parameters.
+ *
+ * This composable uses two `NumberPickerComposable` components to let users select hours and
+ * minutes independently. A `Text` component displays a colon (`:`) separator between the hour and
+ * minute pickers. The layout is responsive and adapts to various screen widths.
+ *
+ * Example Usage:
+ * ```
+ * WheelTimePicker(
+ *     selectedHour = 12,
+ *     selectedMinute = 30,
+ *     onTimeSelected = { hour, minute ->
+ *         println("Selected time: $hour:$minute")
+ *     }
+ * )
+ * ```
+ */
+@Composable
+fun WheelTimePicker(selectedHour: Int, selectedMinute: Int, onTimeSelected: (Int, Int) -> Unit) {
+  Row(
+      modifier = Modifier.fillMaxWidth().padding(horizontal = PADDING_32.dp),
+      horizontalArrangement = Arrangement.SpaceAround,
+      verticalAlignment = Alignment.CenterVertically) {
+        // Hour Picker
+        NumberPickerComposable(
+            value = selectedHour,
+            range = 0..23,
+            onValueChange = { hour -> onTimeSelected(hour, selectedMinute) },
+            modifier = Modifier.weight(1f).testTag(HOUR_PICKER))
+
+        Text(
+            text = ":",
+            style = MaterialTheme.typography.displayLarge,
+            color = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier.align(Alignment.CenterVertically))
+
+        // Minute Picker
+        NumberPickerComposable(
+            value = selectedMinute,
+            range = 0..59,
+            onValueChange = { minute -> onTimeSelected(selectedHour, minute) },
+            modifier = Modifier.weight(1f).testTag(MINUTE_PICKER))
+      }
+}
+
+/**
+ * A composable function that wraps a native Android `NumberPicker` for use in Jetpack Compose.
+ *
+ * @param value The currently selected value of the `NumberPicker`.
+ * @param range The valid range of values (inclusive) that the `NumberPicker` can display.
+ * @param onValueChange A callback triggered when the user selects a new value. It provides the
+ *   selected value as a parameter.
+ * @param modifier A `Modifier` to apply to the `NumberPicker` composable.
+ *
+ * This composable uses `AndroidView` to integrate the native Android `NumberPicker` widget into a
+ * Compose layout. It exposes the current value as a semantic property for testing and
+ * accessibility. The value is dynamically updated when the `value` parameter changes.
+ *
+ * Example Usage:
+ * ```
+ * NumberPickerComposable(
+ *     value = 5,
+ *     range = 0..10,
+ *     onValueChange = { newValue ->
+ *         println("New value: $newValue")
+ *     }
+ * )
+ * ```
+ */
+@Composable
+fun NumberPickerComposable(
+    value: Int,
+    range: IntRange,
+    onValueChange: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+  AndroidView(
+      modifier = modifier.semantics { contentDescription = value.toString() },
+      factory = { context ->
+        NumberPicker(context).apply {
+          minValue = range.first
+          maxValue = range.last
+          this.value = value
+          setOnValueChangedListener { _, _, newValue -> onValueChange(newValue) }
+        }
+      },
+      update = { numberPicker ->
+        // Update the NumberPicker's value dynamically if needed
+        if (numberPicker.value != value) {
+          numberPicker.value = value
+        }
+      })
+}

--- a/app/src/main/java/com/android/sample/ui/createRecipe/TimePickerScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/TimePickerScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -79,8 +79,8 @@ fun TimePickerContent(
   val initialHours = totalMinutes / 60
   val initialMinutes = totalMinutes % 60
 
-  val hours = remember { mutableStateOf(initialHours) }
-  val minutes = remember { mutableStateOf(initialMinutes) }
+  val hours = remember { mutableIntStateOf(initialHours) }
+  val minutes = remember { mutableIntStateOf(initialMinutes) }
 
   Box(modifier = modifier.padding(PADDING_8.dp), contentAlignment = Alignment.TopCenter) {
     Column(
@@ -119,11 +119,11 @@ fun TimePickerContent(
 
           // WheelTimePicker
           WheelTimePicker(
-              selectedHour = hours.value,
-              selectedMinute = minutes.value,
+              selectedHour = hours.intValue,
+              selectedMinute = minutes.intValue,
               onTimeSelected = { selectedHour, selectedMinute ->
-                hours.value = selectedHour
-                minutes.value = selectedMinute
+                hours.intValue = selectedHour
+                minutes.intValue = selectedMinute
               })
 
           Spacer(modifier = Modifier.weight(6f))
@@ -134,7 +134,7 @@ fun TimePickerContent(
         text = stringResource(R.string.next_step),
         modifier = Modifier.align(Alignment.BottomCenter).testTag(NEXT_BUTTON),
         onClick = {
-          val totalTimeInMinutes = (hours.value * 60) + minutes.value
+          val totalTimeInMinutes = (hours.intValue * 60) + minutes.intValue
           createRecipeViewModel.updateRecipeTime(totalTimeInMinutes.toString())
           navigationActions.navigateTo(Screen.CREATE_RECIPE_ADD_IMAGE)
         })

--- a/app/src/main/java/com/android/sample/ui/createRecipe/TimePickerScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/TimePickerScreen.kt
@@ -28,7 +28,9 @@ import com.android.sample.model.recipe.CreateRecipeViewModel
 import com.android.sample.resources.C.Dimension.PADDING_32
 import com.android.sample.resources.C.Dimension.PADDING_8
 import com.android.sample.resources.C.Tag.THIRD_STEP_OF_THE_CREATION
+import com.android.sample.resources.C.TestTag.TimePicker.HOURS_LABEL
 import com.android.sample.resources.C.TestTag.TimePicker.HOUR_PICKER
+import com.android.sample.resources.C.TestTag.TimePicker.MINUTES_LABEL
 import com.android.sample.resources.C.TestTag.TimePicker.MINUTE_PICKER
 import com.android.sample.resources.C.TestTag.TimePicker.NEXT_BUTTON
 import com.android.sample.resources.C.TestTag.TimePicker.TIME_PICKER_DESCRIPTION
@@ -168,25 +170,46 @@ fun WheelTimePicker(selectedHour: Int, selectedMinute: Int, onTimeSelected: (Int
       modifier = Modifier.fillMaxWidth().padding(horizontal = PADDING_32.dp),
       horizontalArrangement = Arrangement.SpaceAround,
       verticalAlignment = Alignment.CenterVertically) {
-        // Hour Picker
-        NumberPickerComposable(
-            value = selectedHour,
-            range = 0..23,
-            onValueChange = { hour -> onTimeSelected(hour, selectedMinute) },
-            modifier = Modifier.weight(1f).testTag(HOUR_PICKER))
+        // Hour Column
+        Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.weight(1f)) {
+          // Label for Hour
+          Text(
+              text = stringResource(R.string.hours),
+              style = MaterialTheme.typography.bodySmall,
+              color = MaterialTheme.colorScheme.onPrimary,
+              modifier = Modifier.testTag(HOURS_LABEL))
 
+          // Hour Picker
+          NumberPickerComposable(
+              value = selectedHour,
+              range = 0..23,
+              onValueChange = { hour -> onTimeSelected(hour, selectedMinute) },
+              modifier = Modifier.testTag(HOUR_PICKER))
+        }
+
+        // Colon Separator
         Text(
             text = ":",
             style = MaterialTheme.typography.displayLarge,
             color = MaterialTheme.colorScheme.onPrimary,
             modifier = Modifier.align(Alignment.CenterVertically))
 
-        // Minute Picker
-        NumberPickerComposable(
-            value = selectedMinute,
-            range = 0..59,
-            onValueChange = { minute -> onTimeSelected(selectedHour, minute) },
-            modifier = Modifier.weight(1f).testTag(MINUTE_PICKER))
+        // Minute Column
+        Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.weight(1f)) {
+          // Label for Minute
+          Text(
+              text = stringResource(R.string.minutes),
+              style = MaterialTheme.typography.bodySmall,
+              color = MaterialTheme.colorScheme.onPrimary,
+              modifier = Modifier.testTag(MINUTES_LABEL))
+
+          // Minute Picker
+          NumberPickerComposable(
+              value = selectedMinute,
+              range = 0..59,
+              onValueChange = { minute -> onTimeSelected(selectedHour, minute) },
+              modifier = Modifier.testTag(MINUTE_PICKER))
+        }
       }
 }
 

--- a/app/src/main/java/com/android/sample/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/sample/ui/navigation/NavigationActions.kt
@@ -53,6 +53,8 @@ object Screen {
   const val CREATE_RECIPE_ADD_IMAGE = "Create Recipe Add Image Screen"
 
   const val CREATE_RECIPE_LIST_INGREDIENTS = "List Ingredients Screen"
+
+  const val CREATE_RECIPE_TIME_PICKER = "Time Picker Screen"
 }
 
 data class TopLevelDestination(val route: String, val iconId: Int, val textId: String)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,5 +142,6 @@
     //TimePickerScreen
     <string name="select_total_time">Select Total Time</string>
     <string name="select_time_description">Selecting the total time is optional, but it helps others understand how long your recipe will take.</string>
-
+    <string name="minutes">Minutes</string>
+    <string name="hours">Hours</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,4 +139,8 @@
     <string name = "delete">Delete</string>
     <string name="cancel">Cancel</string>
 
+    //TimePickerScreen
+    <string name="select_total_time">Select Total Time</string>
+    <string name="select_time_description">Selecting the total time is optional, but it helps others understand how long your recipe will take.</string>
+
 </resources>


### PR DESCRIPTION
# **Description**
- **What has been changed?**  
  A new screen (`TimePickerScreen`) has been added to the recipe creation flow. It allows users to optionally input the total preparation time for their recipe using hour and minute selectors. The selected time is stored in minutes in the `CreateRecipeViewModel` and integrates seamlessly into the existing navigation flow.
![image](https://github.com/user-attachments/assets/25268988-a9c5-4235-b60e-0b71ee9786f0)


- **Why was this change made?**  
  This feature was added to enhance the recipe creation process, enabling users to provide an optional preparation time for better recipe context.

---

# **Code Snippets**

### **`WheelTimePicker`**
This composable uses two `NumberPickerComposable` components to let users select hours and minutes independently. A `Text` component displays a colon (`:`) separator between the hour and minute pickers. The layout is responsive and adapts to various screen widths.

**Example Usage:**
```kotlin
WheelTimePicker(
    selectedHour = 12,
    selectedMinute = 30,
    onTimeSelected = { hour, minute ->
        println("Selected time: $hour:$minute")
    }
)
```

### **`NumberPickerComposable`**
This composable uses `AndroidView` to integrate the native Android `NumberPicker` widget into a Compose layout. It exposes the current value as a semantic property for testing and accessibility. The value is dynamically updated when the `value` parameter changes.

**Example Usage:**
```kotlin
NumberPickerComposable(
    value = 5,
    range = 0..10,
    onValueChange = { newValue ->
        println("New value: $newValue")
    }
)
```

---

# **Problems Encountered**
1. **Initial Attempt Using a Third-Party Library:**  
   Initially tried implementing the picker using [WheelPickerCompose](https://github.com/commandiron/WheelPickerCompose/tree/master). However, this library is under the Apache-2.0 license, which required us to abandon the implementation to avoid licensing conflicts.  

2. **UI Testing with Native `NumberPicker`:**  
   The native Android `NumberPicker` does not expose its values directly to Compose's testing APIs. To resolve this, semantic properties were added to the `NumberPickerComposable` to expose the current value for testing purposes.  

---

# **Checklist**
- [x] Tests added.  
  Unit and E2E tests have been added for `TimePickerScreen` and its integration with the recipe creation flow.

- [x] Documentation updated.  
  Inline comments and descriptions have been added for `TimePickerScreen`, `WheelTimePicker`, and `NumberPickerComposable`.

- [x] All CI checks passed.  
  Verified that all tests, linting, and build processes pass successfully with coverage > 80% on `SonarCloud`.

- [x] Linked issue/feature:  
  #231  

