### PR TITLE
Fix/fridge backend

### DIFF
--- a/app/src/main/java/com/android/sample/model/user/UserRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/sample/model/user/UserRepositoryFirestore.kt
@@ -92,7 +92,7 @@ class UserRepositoryFirestore(private val db: FirebaseFirestore) : UserRepositor
   @Suppress("UNCHECKED_CAST")
   private fun fridgeItemExtraction(mapping: Map<String, Any>): FridgeItem {
     val id = mapping[FRIDGE_FIELD_ID] as String
-    val quantity = mapping[FRIDGE_FIELD_QUANTITY] as Int
+    val quantity = (mapping[FRIDGE_FIELD_QUANTITY] as Long).toInt()
     val dateMap = mapping[FRIDGE_FIELD_EXPIRATION_DATE] as Map<String, Any>
     val date =
         LocalDate.of(

--- a/app/src/test/java/com/android/sample/model/user/UserRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/sample/model/user/UserRepositoryFirestoreTest.kt
@@ -148,7 +148,7 @@ class UserRepositoryFirestoreTest {
     val mapping =
         mapOf(
             FRIDGE_FIELD_ID to fridgeItemExample.id,
-            FRIDGE_FIELD_QUANTITY to fridgeItemExample.quantity,
+            FRIDGE_FIELD_QUANTITY to fridgeItemExample.quantity.toLong(),
             FRIDGE_FIELD_EXPIRATION_DATE to
                 mapOf(
                     FRIDGE_FIELD_EXPIRATION_DATE_YEAR to
@@ -177,7 +177,7 @@ class UserRepositoryFirestoreTest {
             listOf(
                 mapOf(
                     FRIDGE_FIELD_ID to fridgeItemExample.id,
-                    FRIDGE_FIELD_QUANTITY to fridgeItemExample.quantity,
+                    FRIDGE_FIELD_QUANTITY to fridgeItemExample.quantity.toLong(),
                     FRIDGE_FIELD_EXPIRATION_DATE to
                         mapOf(
                             FRIDGE_FIELD_EXPIRATION_DATE_YEAR to


### PR DESCRIPTION
## Description
### What has been changed?
In this PR, a bug was fixed where the ingredients were uploaded to the user's databse entry but when not able to be fetched when going to the fridge or when getting the current user. This was caused by a bad casting of the quantity of a certain FridgeItem.
In order to fix this, the casting of the quantity was changed:
- Before modifications:
```kotlin
val quantity = mapping[FRIDGE_FIELD_QUANTITY] as Int
```
- After modifications: 
```kotlin
val quantity = (mapping[FRIDGE_FIELD_QUANTITY] as Long).toInt()
```
The part `(... as Long).toInt()` does not cause any trouble because we are storing Integers. Thus, we can safely assume that we are always getting Integers and not Longs
### Why was this change made?
These changes were made to be able to fetch an ingredient from the users fridge and to show them in the fridge tab.
## Checklist
- [x] Tests added.
- [ ] Documentation updated.
- [x] All CI checks passed.
- [x] Linked issue/feature (if applicable): #256 
