### PR TITLE
Fix/search ingredient issue

### DIFF
--- a/app/src/main/java/com/android/sample/model/ingredient/SearchIngredientViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/ingredient/SearchIngredientViewModel.kt
@@ -130,7 +130,7 @@ interface SearchIngredientViewModel {
         }
       } else {
         // Ingredient doesn't exist; add it to the list
-        currentList + (ingredient to ingredient.quantity)
+        currentList + (ingredient to (ingredient.quantity?.replaceFirst(",", ".") ?: ""))
       }
     }
   }

--- a/app/src/main/java/com/android/sample/model/ingredient/SearchIngredientViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/ingredient/SearchIngredientViewModel.kt
@@ -60,6 +60,7 @@ interface SearchIngredientViewModel {
    * @param quantity2: the second string quantity to add
    */
   private fun addFirstInt(quantity1: String?, quantity2: String?): String {
+    /*
     if (quantity1 == null || quantity2 == null) {
       return quantity1 ?: quantity2 ?: ""
     }
@@ -73,6 +74,33 @@ interface SearchIngredientViewModel {
     return if (match1 != null && match2 != null) {
       val addition = match1.value.toInt() + match2.value.toInt()
       quantity1.replaceFirst(match1.value, addition.toString())
+    } else if (match1 != null) {
+      quantity1
+    } else {
+      quantity2
+    }*/
+    if (quantity1 == null || quantity2 == null) {
+      return quantity1 ?: quantity2 ?: ""
+    }
+
+    // Regular expression to find the first number in the string, considering possible decimal
+    // separators
+    val regex = Regex("""\d+[,.]?\d*""")
+
+    val match1 = regex.find(quantity1)
+    val match2 = regex.find(quantity2)
+
+    return if (match1 != null && match2 != null) {
+      // Replace ',' with '.' for both matches to standardize
+      val number1 = match1.value.replace(',', '.').toDouble()
+      val number2 = match2.value.replace(',', '.').toDouble()
+      val addition = number1 + number2
+
+      // Format the result, replace the first occurrence, and return
+      quantity1
+          .replaceFirst(match1.value, addition.toString())
+          .replaceFirst(".0", "")
+          .replaceFirst(",0", "")
     } else if (match1 != null) {
       quantity1
     } else {

--- a/app/src/main/java/com/android/sample/model/ingredient/SearchIngredientViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/ingredient/SearchIngredientViewModel.kt
@@ -54,35 +54,15 @@ interface SearchIngredientViewModel {
   fun fetchIngredientByName(name: String)
 
   /**
-   * Add the first integer in the two strings
+   * Perform an addition operation of the first integers of two string quantities
    *
    * @param quantity1: the first string quantity to add
    * @param quantity2: the second string quantity to add
    */
   private fun addFirstInt(quantity1: String?, quantity2: String?): String {
-    /*
     if (quantity1 == null || quantity2 == null) {
       return quantity1 ?: quantity2 ?: ""
     }
-
-    // Regular expression to find the first integer in the string
-    val regex = Regex("""\d+""")
-    val match1 = regex.find(quantity1)
-    val match2 = regex.find(quantity2)
-
-    // If both strings contain an integer, add them together
-    return if (match1 != null && match2 != null) {
-      val addition = match1.value.toInt() + match2.value.toInt()
-      quantity1.replaceFirst(match1.value, addition.toString())
-    } else if (match1 != null) {
-      quantity1
-    } else {
-      quantity2
-    }*/
-    if (quantity1 == null || quantity2 == null) {
-      return quantity1 ?: quantity2 ?: ""
-    }
-
     // Regular expression to find the first number in the string, considering possible decimal
     // separators
     val regex = Regex("""\d+[,.]?\d*""")
@@ -96,7 +76,7 @@ interface SearchIngredientViewModel {
       val number2 = match2.value.replace(',', '.').toDouble()
       val addition = number1 + number2
 
-      // Format the result, replace the first occurrence, and return
+      // Format the result, replace the first occurrence, delete .0 and ,0 and return
       quantity1
           .replaceFirst(match1.value, addition.toString())
           .replaceFirst(".0", "")

--- a/app/src/main/java/com/android/sample/model/ingredient/SearchIngredientViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/ingredient/SearchIngredientViewModel.kt
@@ -77,10 +77,7 @@ interface SearchIngredientViewModel {
       val addition = number1 + number2
 
       // Format the result, replace the first occurrence, delete .0 and ,0 and return
-      quantity1
-          .replaceFirst(match1.value, addition.toString())
-          .replaceFirst(".0", "")
-          .replaceFirst(",0", "")
+      quantity1.replaceFirst(match1.value, addition.toString()).replaceFirst(".0", "")
     } else if (match1 != null) {
       quantity1
     } else {

--- a/app/src/test/java/com/android/sample/model/ingredient/IngredientViewModelTest.kt
+++ b/app/src/test/java/com/android/sample/model/ingredient/IngredientViewModelTest.kt
@@ -462,6 +462,192 @@ class IngredientViewModelTest {
   }
 
   @Test
+  fun addIngredientWithPointRegexIngredientTest() {
+    // Create an initial ingredient
+    val ingredient =
+        Ingredient(
+            barCode = 123456L,
+            name = "Test Ingredient",
+            brands = "Brand",
+            quantity = "1.5",
+            categories = listOf("Category1"),
+            images =
+                mutableMapOf(
+                    PRODUCT_FRONT_IMAGE_NORMAL_URL to "https://display_normal",
+                    PRODUCT_FRONT_IMAGE_THUMBNAIL_URL to "https://display_thumbnail",
+                    PRODUCT_FRONT_IMAGE_SMALL_URL to "https://display_small"))
+
+    // Add the ingredient to the ingredient list
+    ingredientViewModel.addIngredient(ingredient)
+    ingredientViewModel.addIngredient(ingredient)
+
+    // Verify that the ingredient list contains the ingredient with the updated quantity
+    val updatedIngredient =
+        ingredientViewModel.ingredientList.value.find { it.first.barCode == ingredient.barCode }
+    assertNotNull(updatedIngredient)
+    assertEquals("3", updatedIngredient?.second)
+  }
+
+  @Test
+  fun addTwoIngredientWithCommaRegexIngredientTest() {
+    // Create an initial ingredient
+    val ingredient =
+        Ingredient(
+            barCode = 123456L,
+            name = "Test Ingredient",
+            brands = "Brand",
+            quantity = "1,5",
+            categories = listOf("Category1"),
+            images =
+                mutableMapOf(
+                    PRODUCT_FRONT_IMAGE_NORMAL_URL to "https://display_normal",
+                    PRODUCT_FRONT_IMAGE_THUMBNAIL_URL to "https://display_thumbnail",
+                    PRODUCT_FRONT_IMAGE_SMALL_URL to "https://display_small"))
+
+    // Add the ingredient to the ingredient list
+    ingredientViewModel.addIngredient(ingredient)
+    ingredientViewModel.addIngredient(ingredient)
+
+    // Verify that the ingredient list contains the ingredient with the updated quantity
+    val updatedIngredient =
+        ingredientViewModel.ingredientList.value.find { it.first.barCode == ingredient.barCode }
+    assertNotNull(updatedIngredient)
+    assertEquals("3", updatedIngredient?.second)
+  }
+
+  @Test
+  fun addOneIngredientWithCommaRegexIngredientTest() {
+    // Create an initial ingredient
+    val ingredient =
+        Ingredient(
+            barCode = 123456L,
+            name = "Test Ingredient",
+            brands = "Brand",
+            quantity = "1,5",
+            categories = listOf("Category1"),
+            images =
+                mutableMapOf(
+                    PRODUCT_FRONT_IMAGE_NORMAL_URL to "https://display_normal",
+                    PRODUCT_FRONT_IMAGE_THUMBNAIL_URL to "https://display_thumbnail",
+                    PRODUCT_FRONT_IMAGE_SMALL_URL to "https://display_small"))
+
+    // Add the ingredient to the ingredient list
+    ingredientViewModel.addIngredient(ingredient)
+
+    // Verify that the ingredient list contains the ingredient with the updated quantity
+    val updatedIngredient =
+        ingredientViewModel.ingredientList.value.find { it.first.barCode == ingredient.barCode }
+    assertNotNull(updatedIngredient)
+    assertEquals("1.5", updatedIngredient?.second)
+  }
+
+  @Test
+  fun addIngredientWithMultipleCommaRegexIngredientTest() {
+    // Create an initial ingredient
+    val ingredient =
+        Ingredient(
+            barCode = 123456L,
+            name = "Test Ingredient",
+            brands = "Brand",
+            quantity = "1,5 ingredient, pasta",
+            categories = listOf("Category1"),
+            images =
+                mutableMapOf(
+                    PRODUCT_FRONT_IMAGE_NORMAL_URL to "https://display_normal",
+                    PRODUCT_FRONT_IMAGE_THUMBNAIL_URL to "https://display_thumbnail",
+                    PRODUCT_FRONT_IMAGE_SMALL_URL to "https://display_small"))
+
+    // Add the ingredient to the ingredient list
+    ingredientViewModel.addIngredient(ingredient)
+
+    // Verify that the ingredient list contains the ingredient with the updated quantity
+    val updatedIngredient =
+        ingredientViewModel.ingredientList.value.find { it.first.barCode == ingredient.barCode }
+    assertNotNull(updatedIngredient)
+    assertEquals("1.5 ingredient, pasta", updatedIngredient?.second)
+  }
+
+  @Test
+  fun addTwoIngredientWithCommaAndNoRegexIngredientTest() {
+    // Create an initial ingredient
+    val ingredient1 =
+        Ingredient(
+            barCode = 123456L,
+            name = "Test Ingredient",
+            brands = "Brand",
+            quantity = "1,5",
+            categories = listOf("Category1"),
+            images =
+                mutableMapOf(
+                    PRODUCT_FRONT_IMAGE_NORMAL_URL to "https://display_normal",
+                    PRODUCT_FRONT_IMAGE_THUMBNAIL_URL to "https://display_thumbnail",
+                    PRODUCT_FRONT_IMAGE_SMALL_URL to "https://display_small"))
+
+    val ingredient2 =
+        Ingredient(
+            barCode = 123456L,
+            name = "Test Ingredient",
+            brands = "Brand",
+            quantity = "1",
+            categories = listOf("Category1"),
+            images =
+                mutableMapOf(
+                    PRODUCT_FRONT_IMAGE_NORMAL_URL to "https://display_normal",
+                    PRODUCT_FRONT_IMAGE_THUMBNAIL_URL to "https://display_thumbnail",
+                    PRODUCT_FRONT_IMAGE_SMALL_URL to "https://display_small"))
+
+    // Add the ingredient to the ingredient list
+    ingredientViewModel.addIngredient(ingredient1)
+    ingredientViewModel.addIngredient(ingredient2)
+
+    // Verify that the ingredient list contains the ingredient with the updated quantity
+    val updatedIngredient =
+        ingredientViewModel.ingredientList.value.find { it.first.barCode == ingredient1.barCode }
+    assertNotNull(updatedIngredient)
+    assertEquals("2.5", updatedIngredient?.second)
+  }
+
+  @Test
+  fun addIngredientWithPointAndNoRegexIngredientTest() {
+    // Create an initial ingredient
+    val ingredient1 =
+        Ingredient(
+            barCode = 123456L,
+            name = "Test Ingredient",
+            brands = "Brand",
+            quantity = "1.5",
+            categories = listOf("Category1"),
+            images =
+                mutableMapOf(
+                    PRODUCT_FRONT_IMAGE_NORMAL_URL to "https://display_normal",
+                    PRODUCT_FRONT_IMAGE_THUMBNAIL_URL to "https://display_thumbnail",
+                    PRODUCT_FRONT_IMAGE_SMALL_URL to "https://display_small"))
+
+    val ingredient2 =
+        Ingredient(
+            barCode = 123456L,
+            name = "Test Ingredient",
+            brands = "Brand",
+            quantity = "1",
+            categories = listOf("Category1"),
+            images =
+                mutableMapOf(
+                    PRODUCT_FRONT_IMAGE_NORMAL_URL to "https://display_normal",
+                    PRODUCT_FRONT_IMAGE_THUMBNAIL_URL to "https://display_thumbnail",
+                    PRODUCT_FRONT_IMAGE_SMALL_URL to "https://display_small"))
+
+    // Add the ingredient to the ingredient list
+    ingredientViewModel.addIngredient(ingredient1)
+    ingredientViewModel.addIngredient(ingredient2)
+
+    // Verify that the ingredient list contains the ingredient with the updated quantity
+    val updatedIngredient =
+        ingredientViewModel.ingredientList.value.find { it.first.barCode == ingredient1.barCode }
+    assertNotNull(updatedIngredient)
+    assertEquals("2.5", updatedIngredient?.second)
+  }
+
+  @Test
   fun clearIngredientTest() {
     val barCode = 123456L
     val ingredient = testIngredients[0].copy(barCode = barCode)

--- a/app/src/test/java/com/android/sample/model/user/UserViewModelTest.kt
+++ b/app/src/test/java/com/android/sample/model/user/UserViewModelTest.kt
@@ -740,6 +740,192 @@ class UserViewModelTest {
   }
 
   @Test
+  fun addIngredientWithPointRegexIngredientTest() {
+    // Create an initial ingredient
+    val ingredient =
+        Ingredient(
+            barCode = 123456L,
+            name = "Test Ingredient",
+            brands = "Brand",
+            quantity = "1.5",
+            categories = listOf("Category1"),
+            images =
+                mutableMapOf(
+                    PRODUCT_FRONT_IMAGE_NORMAL_URL to "https://display_normal",
+                    PRODUCT_FRONT_IMAGE_THUMBNAIL_URL to "https://display_thumbnail",
+                    PRODUCT_FRONT_IMAGE_SMALL_URL to "https://display_small"))
+
+    // Add the ingredient to the ingredient list
+    userViewModel.addIngredient(ingredient)
+    userViewModel.addIngredient(ingredient)
+
+    // Verify that the ingredient list contains the ingredient with the updated quantity
+    val updatedIngredient =
+        userViewModel.ingredientList.value.find { it.first.barCode == ingredient.barCode }
+    assertNotNull(updatedIngredient)
+    TestCase.assertEquals("3", updatedIngredient?.second)
+  }
+
+  @Test
+  fun addIngredientWithCommaRegexIngredientTest() {
+    // Create an initial ingredient
+    val ingredient =
+        Ingredient(
+            barCode = 123456L,
+            name = "Test Ingredient",
+            brands = "Brand",
+            quantity = "1,5",
+            categories = listOf("Category1"),
+            images =
+                mutableMapOf(
+                    PRODUCT_FRONT_IMAGE_NORMAL_URL to "https://display_normal",
+                    PRODUCT_FRONT_IMAGE_THUMBNAIL_URL to "https://display_thumbnail",
+                    PRODUCT_FRONT_IMAGE_SMALL_URL to "https://display_small"))
+
+    // Add the ingredient to the ingredient list
+    userViewModel.addIngredient(ingredient)
+
+    // Verify that the ingredient list contains the ingredient with the updated quantity
+    val updatedIngredient =
+        userViewModel.ingredientList.value.find { it.first.barCode == ingredient.barCode }
+    assertNotNull(updatedIngredient)
+    TestCase.assertEquals("1.5", updatedIngredient?.second)
+  }
+
+  @Test
+  fun addIngredientWithMultipleCommaRegexIngredientTest() {
+    // Create an initial ingredient
+    val ingredient =
+        Ingredient(
+            barCode = 123456L,
+            name = "Test Ingredient",
+            brands = "Brand",
+            quantity = "1,5 ingredient, pasta",
+            categories = listOf("Category1"),
+            images =
+                mutableMapOf(
+                    PRODUCT_FRONT_IMAGE_NORMAL_URL to "https://display_normal",
+                    PRODUCT_FRONT_IMAGE_THUMBNAIL_URL to "https://display_thumbnail",
+                    PRODUCT_FRONT_IMAGE_SMALL_URL to "https://display_small"))
+
+    // Add the ingredient to the ingredient list
+    userViewModel.addIngredient(ingredient)
+
+    // Verify that the ingredient list contains the ingredient with the updated quantity
+    val updatedIngredient =
+        userViewModel.ingredientList.value.find { it.first.barCode == ingredient.barCode }
+    assertNotNull(updatedIngredient)
+    TestCase.assertEquals("1.5 ingredient, pasta", updatedIngredient?.second)
+  }
+
+  @Test
+  fun addTwoIngredientWithCommaRegexIngredientTest() {
+    // Create an initial ingredient
+    val ingredient =
+        Ingredient(
+            barCode = 123456L,
+            name = "Test Ingredient",
+            brands = "Brand",
+            quantity = "1,5",
+            categories = listOf("Category1"),
+            images =
+                mutableMapOf(
+                    PRODUCT_FRONT_IMAGE_NORMAL_URL to "https://display_normal",
+                    PRODUCT_FRONT_IMAGE_THUMBNAIL_URL to "https://display_thumbnail",
+                    PRODUCT_FRONT_IMAGE_SMALL_URL to "https://display_small"))
+
+    // Add the ingredient to the ingredient list
+    userViewModel.addIngredient(ingredient)
+    userViewModel.addIngredient(ingredient)
+
+    // Verify that the ingredient list contains the ingredient with the updated quantity
+    val updatedIngredient =
+        userViewModel.ingredientList.value.find { it.first.barCode == ingredient.barCode }
+    assertNotNull(updatedIngredient)
+    TestCase.assertEquals("3", updatedIngredient?.second)
+  }
+
+  @Test
+  fun addIngredientWithCommaAndNoRegexIngredientTest() {
+    // Create an initial ingredient
+    val ingredient1 =
+        Ingredient(
+            barCode = 123456L,
+            name = "Test Ingredient",
+            brands = "Brand",
+            quantity = "1,5",
+            categories = listOf("Category1"),
+            images =
+                mutableMapOf(
+                    PRODUCT_FRONT_IMAGE_NORMAL_URL to "https://display_normal",
+                    PRODUCT_FRONT_IMAGE_THUMBNAIL_URL to "https://display_thumbnail",
+                    PRODUCT_FRONT_IMAGE_SMALL_URL to "https://display_small"))
+
+    val ingredient2 =
+        Ingredient(
+            barCode = 123456L,
+            name = "Test Ingredient",
+            brands = "Brand",
+            quantity = "1",
+            categories = listOf("Category1"),
+            images =
+                mutableMapOf(
+                    PRODUCT_FRONT_IMAGE_NORMAL_URL to "https://display_normal",
+                    PRODUCT_FRONT_IMAGE_THUMBNAIL_URL to "https://display_thumbnail",
+                    PRODUCT_FRONT_IMAGE_SMALL_URL to "https://display_small"))
+
+    // Add the ingredient to the ingredient list
+    userViewModel.addIngredient(ingredient1)
+    userViewModel.addIngredient(ingredient2)
+
+    // Verify that the ingredient list contains the ingredient with the updated quantity
+    val updatedIngredient =
+        userViewModel.ingredientList.value.find { it.first.barCode == ingredient1.barCode }
+    assertNotNull(updatedIngredient)
+    TestCase.assertEquals("2.5", updatedIngredient?.second)
+  }
+
+  @Test
+  fun addIngredientWithPointAndNoRegexIngredientTest() {
+    // Create an initial ingredient
+    val ingredient1 =
+        Ingredient(
+            barCode = 123456L,
+            name = "Test Ingredient",
+            brands = "Brand",
+            quantity = "1.5",
+            categories = listOf("Category1"),
+            images =
+                mutableMapOf(
+                    PRODUCT_FRONT_IMAGE_NORMAL_URL to "https://display_normal",
+                    PRODUCT_FRONT_IMAGE_THUMBNAIL_URL to "https://display_thumbnail",
+                    PRODUCT_FRONT_IMAGE_SMALL_URL to "https://display_small"))
+
+    val ingredient2 =
+        Ingredient(
+            barCode = 123456L,
+            name = "Test Ingredient",
+            brands = "Brand",
+            quantity = "1",
+            categories = listOf("Category1"),
+            images =
+                mutableMapOf(
+                    PRODUCT_FRONT_IMAGE_NORMAL_URL to "https://display_normal",
+                    PRODUCT_FRONT_IMAGE_THUMBNAIL_URL to "https://display_thumbnail",
+                    PRODUCT_FRONT_IMAGE_SMALL_URL to "https://display_small"))
+
+    // Add the ingredient to the ingredient list
+    userViewModel.addIngredient(ingredient1)
+    userViewModel.addIngredient(ingredient2)
+
+    // Verify that the ingredient list contains the ingredient with the updated quantity
+    val updatedIngredient =
+        userViewModel.ingredientList.value.find { it.first.barCode == ingredient1.barCode }
+    assertNotNull(updatedIngredient)
+    TestCase.assertEquals("2.5", updatedIngredient?.second)
+  }
+
+  @Test
   fun clearIngredientTest() {
     val barCode = 123456L
     val ingredient = testIngredients[0].copy(barCode = barCode)


### PR DESCRIPTION
#  Search ingredient comma fix 

## Description
This PR fixes a bug in the `addFirstInt` method where quantities with commas (,) as decimal separators (e.g., `1,5`) were not being handled correctly during addition. The method now treats commas and points (.) as equivalent, ensuring consistent computations. Additionally, trailing zeros after whole numbers (e.g., `3.0`) are removed for cleaner results.

### What has been changed?
- Updated the  `addFirstInt` method to handle quantities with commas (,) and points (.) consistently by treating them as equivalent decimal separators.
```kotlin
 val number1 = match1.value.replace(',', '.').toDouble()
 val number2 = match2.value.replace(',', '.').toDouble()
```
- Ensured the addition of numbers with mixed formats (e.g., `1,5` + `1.5` = `3`) is calculated correctly by adding the `,` and `.` in regex pattern:
```kotlin
 val regex = Regex("""\d+[,.]?\d*""")
```
- Enhanced the logic to remove trailing zeros after addition (e.g., `3.0` → `3`).
```kotlin
.replaceFirst(".0", "")
```
### Why was this change made?
This change was necessary to fix a bug where quantities containing commas (e.g., `1,5`) were not being handled correctly during the addition process. The previous implementation did not account for commas as valid decimal separators, leading to incorrect results or errors.

## Checklist
- [x] Tests added.
- [x] Documentation updated.
- [x] All CI checks passed.
- [x] Linked issue/feature: #273 
