### PR TITLE
bugfix : twice same img in swipe page

### DIFF
--- a/app/src/main/java/com/android/sample/ui/swipePage/SwipePage.kt
+++ b/app/src/main/java/com/android/sample/ui/swipePage/SwipePage.kt
@@ -150,10 +150,10 @@ import com.android.sample.ui.theme.starColor
 import com.android.sample.ui.utils.PlateSwipeScaffold
 import com.android.sample.ui.utils.Tag
 import com.android.sample.utils.NetworkUtils
-import kotlinx.coroutines.launch
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
+import kotlinx.coroutines.launch
 
 /**
  * Composable for the Swipe Page

--- a/app/src/main/java/com/android/sample/ui/swipePage/SwipePage.kt
+++ b/app/src/main/java/com/android/sample/ui/swipePage/SwipePage.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.rememberAsyncImagePainter
 import com.android.sample.R
 import com.android.sample.model.filter.Difficulty
 import com.android.sample.model.recipe.Recipe
@@ -147,13 +148,12 @@ import com.android.sample.ui.theme.jungleGreen
 import com.android.sample.ui.theme.redSwipe
 import com.android.sample.ui.theme.starColor
 import com.android.sample.ui.utils.PlateSwipeScaffold
-import com.android.sample.ui.utils.RecipeImage
 import com.android.sample.ui.utils.Tag
 import com.android.sample.utils.NetworkUtils
+import kotlinx.coroutines.launch
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
-import kotlinx.coroutines.launch
 
 /**
  * Composable for the Swipe Page
@@ -374,12 +374,16 @@ fun RecipeDisplay(
                       Column(
                           modifier =
                               Modifier.background(color = MaterialTheme.colorScheme.onPrimary)) {
-                            RecipeImage(
-                                displayCard1,
-                                currentRecipe,
-                                nextRecipe,
-                                isConnected,
-                                RECIPE_IMAGE_1)
+                            Image(
+                                painter =
+                                    rememberAsyncImagePainter(
+                                        model =
+                                            if (displayCard1) currentRecipe?.url
+                                            else nextRecipe?.url),
+                                contentDescription = stringResource(R.string.recipe_image),
+                                modifier = Modifier.fillMaxSize().testTag(RECIPE_IMAGE_1),
+                                contentScale = ContentScale.Crop,
+                            )
                           }
                     }
 
@@ -395,12 +399,16 @@ fun RecipeDisplay(
                       Column(
                           modifier =
                               Modifier.background(color = MaterialTheme.colorScheme.onPrimary)) {
-                            RecipeImage(
-                                displayCard1,
-                                currentRecipe,
-                                nextRecipe,
-                                isConnected,
-                                RECIPE_IMAGE_2)
+                            Image(
+                                painter =
+                                    rememberAsyncImagePainter(
+                                        model =
+                                            if (!displayCard1) currentRecipe?.url
+                                            else nextRecipe?.url),
+                                contentDescription = stringResource(R.string.recipe_image),
+                                modifier = Modifier.fillMaxSize().testTag(RECIPE_IMAGE_2),
+                                contentScale = ContentScale.Crop,
+                            )
                           }
                     }
               }

--- a/app/src/main/java/com/android/sample/ui/swipePage/SwipePage.kt
+++ b/app/src/main/java/com/android/sample/ui/swipePage/SwipePage.kt
@@ -149,7 +149,6 @@ import com.android.sample.ui.theme.redSwipe
 import com.android.sample.ui.theme.starColor
 import com.android.sample.ui.utils.PlateSwipeScaffold
 import com.android.sample.ui.utils.Tag
-import com.android.sample.utils.NetworkUtils
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
@@ -214,7 +213,6 @@ fun RecipeDisplay(
   val nextRecipe by recipesViewModel.nextRecipe.collectAsState()
   val filter by recipesViewModel.filter.collectAsState()
   val context = LocalContext.current
-  val isConnected = NetworkUtils().isNetworkAvailable(context)
   Box(
       modifier =
           Modifier.fillMaxSize()

--- a/app/src/main/java/com/android/sample/ui/swipePage/SwipePage.kt
+++ b/app/src/main/java/com/android/sample/ui/swipePage/SwipePage.kt
@@ -212,7 +212,6 @@ fun RecipeDisplay(
   val currentRecipe by recipesViewModel.currentRecipe.collectAsState()
   val nextRecipe by recipesViewModel.nextRecipe.collectAsState()
   val filter by recipesViewModel.filter.collectAsState()
-  val context = LocalContext.current
   Box(
       modifier =
           Modifier.fillMaxSize()


### PR DESCRIPTION
### What has been changed?  
In PR #276, I introduced a new way to display the image on the `SwipePage` when the user has no internet connection. After discussing this implementation with the team, we decided to take a different approach: completely blocking access to the Swipe feature in the absence of an internet connection.  

Additionally, the change introduced a bug where the same image was displayed twice. To address this issue, I reverted to the original code implemented by @AdriB02. Below is a video shared by @akshire showcasing the bug:  

https://github.com/user-attachments/assets/55a67637-7515-4dc0-8666-800358a64c5c

---

### Why was this change made?  
The primary goal of this update was to fix the bug causing duplicate images to appear.  

---

### Checklist  
- [x] Tests added  
- [x] Documentation updated  
- [x] All CI checks passed  
- [ ] Linked issue/feature (if applicable)  

