### PR TITLE
Bugfix/ingredient uid

### DIFF
--- a/app/src/main/java/com/android/sample/model/ingredient/IngredientViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/ingredient/IngredientViewModel.kt
@@ -12,6 +12,7 @@ import com.android.sample.model.ingredient.localData.RoomIngredientRepository
 import com.android.sample.model.ingredient.networkData.AggregatorIngredientRepository
 import com.android.sample.model.ingredient.networkData.FirestoreIngredientRepository
 import com.android.sample.model.ingredient.networkData.OpenFoodFactsIngredientRepository
+import com.android.sample.resources.C.Tag.INGREDIENT_NOT_FOUND_MESSAGE
 import com.android.sample.resources.C.Tag.INGREDIENT_VIEWMODEL_LOG_TAG
 import com.android.sample.resources.C.Tag.INGR_DOWNLOAD_ERROR_DOWNLOAD_IMAGE
 import com.android.sample.resources.C.Tag.INGR_DOWNLOAD_ERROR_GET_ING
@@ -247,6 +248,33 @@ class IngredientViewModel(
         onFailure(e)
       }
     }
+  }
+  /**
+   * Retrieves an ingredient by its barcode.
+   *
+   * @param barCode The barcode of the ingredient to retrieve.
+   * @param onSuccess Callback function to be invoked with the retrieved ingredient if found.
+   * @param onFailure Callback function to be invoked with an exception if an error occurs or the
+   *   ingredient is not found.
+   */
+  fun getIngredient(
+      barCode: Long,
+      onSuccess: (Ingredient) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    repository.get(
+        barCode,
+        { ingredient ->
+          if (ingredient != null) {
+            onSuccess(ingredient)
+          } else {
+            onFailure(Exception(INGREDIENT_NOT_FOUND_MESSAGE))
+          }
+        },
+        onFailure = { e ->
+          Log.e(INGREDIENT_VIEWMODEL_LOG_TAG, INGR_DOWNLOAD_ERROR_GET_ING, e)
+          onFailure(e)
+        })
   }
 
   companion object {

--- a/app/src/main/java/com/android/sample/model/ingredient/networkData/AggregatorIngredientRepository.kt
+++ b/app/src/main/java/com/android/sample/model/ingredient/networkData/AggregatorIngredientRepository.kt
@@ -52,10 +52,13 @@ open class AggregatorIngredientRepository(
                 barCode,
                 onSuccess = { ingredientOpenFoodFacts ->
                   if (ingredientOpenFoodFacts != null) {
-                    // Immediately return the ingredient from OpenFoodFacts
-                    onSuccess(ingredientOpenFoodFacts)
+                    // Immediately return the ingredient from OpenFoodFacts but give it a new UID
+                    val ingredientWithUID =
+                        ingredientOpenFoodFacts.copy(
+                            uid = firestoreIngredientRepository.getNewUid())
+                    onSuccess(ingredientWithUID)
                     // Start the background upload and update process
-                    uploadAndSaveIngredientImages(ingredientOpenFoodFacts, Dispatchers.IO)
+                    uploadAndSaveIngredientImages(ingredientWithUID, Dispatchers.IO)
                   } else {
                     Log.e(AGGREGATOR_LOG_TAG, AGGREGATOR_ERROR_OPENFOOD_INGR_NOT_FOUND)
                     onFailure(Exception(C.Tag.INGREDIENT_NOT_FOUND_MESSAGE))

--- a/app/src/main/java/com/android/sample/model/ingredient/networkData/FirestoreIngredientRepository.kt
+++ b/app/src/main/java/com/android/sample/model/ingredient/networkData/FirestoreIngredientRepository.kt
@@ -4,6 +4,7 @@ import com.android.sample.model.ingredient.Ingredient
 import com.android.sample.model.ingredient.IngredientRepository
 import com.android.sample.resources.C
 import com.android.sample.resources.C.Tag.FIRESTORE_INGREDIENT_CATEGORIES
+import com.android.sample.resources.C.Tag.FIRESTORE_INGREDIENT_COLLECTION_NAME_TEST
 import com.android.sample.resources.C.Tag.FIRESTORE_INGREDIENT_IMAGES
 import com.android.sample.resources.C.Tag.FIRESTORE_INGREDIENT_QUANTITY
 import com.google.firebase.firestore.DocumentSnapshot
@@ -97,7 +98,7 @@ class FirestoreIngredientRepository(private val db: FirebaseFirestore) :
       onFailure: (Exception) -> Unit,
       count: Int = 20
   ) {
-    db.collection(C.Tag.FIRESTORE_INGREDIENT_COLLECTION_NAME_TEST)
+    db.collection(FIRESTORE_INGREDIENT_COLLECTION_NAME_TEST)
         .where(filter)
         .limit(count.toLong())
         .get()
@@ -130,12 +131,10 @@ class FirestoreIngredientRepository(private val db: FirebaseFirestore) :
     var addedIngredient = ingredient
 
     if (ingredient.uid.isNullOrEmpty()) {
-      addedIngredient =
-          ingredient.copy(
-              uid = db.collection(C.Tag.FIRESTORE_INGREDIENT_COLLECTION_NAME_TEST).document().id)
+      addedIngredient = ingredient.copy(uid = getNewUid())
     }
 
-    db.collection(C.Tag.FIRESTORE_INGREDIENT_COLLECTION_NAME_TEST)
+    db.collection(FIRESTORE_INGREDIENT_COLLECTION_NAME_TEST)
         .document(addedIngredient.uid!!)
         .set(addedIngredient)
         .addOnCompleteListener { result ->
@@ -156,5 +155,14 @@ class FirestoreIngredientRepository(private val db: FirebaseFirestore) :
    */
   fun add(ingredient: List<Ingredient>, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
     ingredient.forEach { i -> add(i, onSuccess, onFailure) }
+  }
+
+  /**
+   * Generates a new unique identifier (UID) for an ingredient document.
+   *
+   * @return A new UID as a String.
+   */
+  fun getNewUid(): String {
+    return db.collection(FIRESTORE_INGREDIENT_COLLECTION_NAME_TEST).document().id
   }
 }

--- a/app/src/test/java/com/android/sample/model/ingredient/network/AggregatorIngredientRepositoryTest.kt
+++ b/app/src/test/java/com/android/sample/model/ingredient/network/AggregatorIngredientRepositoryTest.kt
@@ -56,6 +56,7 @@ class AggregatorIngredientRepositoryTest {
   fun setUp() {
     MockitoAnnotations.openMocks(this)
 
+    `when`(mockFirestoreIngredientRepository.getNewUid()).thenReturn("1")
     whenever(mockImageRepository.urlToBitmap(any())).thenReturn(bitmap)
 
     doNothing()

--- a/app/src/test/java/com/android/sample/model/ingredient/network/FirestoreIngredientRepositoryTest.kt
+++ b/app/src/test/java/com/android/sample/model/ingredient/network/FirestoreIngredientRepositoryTest.kt
@@ -214,4 +214,11 @@ class FirestoreIngredientRepositoryTest {
 
     assertNotNull(resultingException)
   }
+
+  @Test
+  fun getNewUid() {
+    `when`(mockDocumentReference.id).thenReturn("1")
+    val uid = firestoreIngredientRepository.getNewUid()
+    assert(uid == "1")
+  }
 }


### PR DESCRIPTION
# What Has Been Changed?

### Ingredient UID
In the `AggregatorIngredientRepository.get` method, when an ingredient is not found in our Firestore collection, we query OpenFoodFacts. Previously, the resulting ingredient was passed to the `onSuccess` callback without generating a UID. This change ensures that a UID is generated before calling the `onSuccess` callback.

### Ingredient ViewModel
A new `getIngredient()` method has been added, which takes a barcode and returns an `Ingredient` object. This method downloads the ingredient if it does not exist in Firestore and ensures it has a valid UID.

---

# Why Was This Change Made?

### Ingredient UID
Previously, not generating a UID before calling the `onSuccess` callback resulted in `Ingredient` objects without UIDs being used briefly within the app. While this did not cause issues for UI tasks, the introduction of offline mode necessitates storing the UID immediately after fetching an ingredient online. Without a UID, the app encountered issues when handling `Ingredient` objects in the UI. This change ensures all `Ingredient` objects have a valid UID.

### Ingredient ViewModel
Currently, the search-by-name functionality, unlike the scanner functionality, does not download ingredients to our Firestore collection. For the fridge, when searching by name, ingredients fetched from OpenFoodFacts are not stored in Firestore. Consequently, when the user relaunches the app, ingredients are retrieved using their barcodes, which triggers their download to Firestore. To address this delay and the associated issue of missing UIDs (see above), the `getIngredient()` method has been added. This method downloads the ingredient and returns it with a Firestore UID immediately, bypassing the need to wait for a full app relaunch.  

This method differs from `fetchIngredient(barCode: Long)` as it does not update the ViewModel's `StateFlow` but instead directly returns the ingredient.

---

## Checklist
- [x] Tests added.
- [x] Documentation updated.
- [x] All CI checks passed.
- [x] Linked issue/feature (if applicable): #289 