### PR TITLE
Fix Bug when ingredients are not correctly merge after editing

### DIFF
--- a/app/src/main/java/com/android/sample/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/user/UserViewModel.kt
@@ -306,8 +306,9 @@ class UserViewModel(
     if (_currentEditingFridgeIngredient.value != null) {
       _fridgeItems.value =
           _fridgeItems.value.filter { it.first != _currentEditingFridgeIngredient.value!!.first }
-      if (quantity != 0) addIngredientToUserFridge(ingredient, quantity, expirationDate)
       clearEditingIngredient()
+      if (quantity != 0)
+          updateIngredientFromFridge(ingredient, quantity, expirationDate, scannedItem)
     } else {
       // add new ingredient case
       val changedIngredient =


### PR DESCRIPTION
# Fix Bug in the fridge when ingredients are not correctly merge after editing
## Description
This pull request addresses a bug in the `UserViewModel` class within the `UserViewModel.kt` file. The issue occurred when ingredients with the same expiration date were not merging correctly after being edited. The changes ensure that ingredients with the same date and non-zero quantity are properly merged in the user's fridge.

### What has been changed?
This PR modifies the way ingredients are updated in the fridge by introducing the following changes:

* Updated the `if` block in the `UserViewModel` to call the `updateIngredientFromFridge` method instead of `addIngredientToUserFridge` when the ingredient quantity is not zero. This update includes passing an additional parameter, scannedItem, to ensure proper merging of ingredients. ([UserViewModel.ktL309-R311](https://github.com/PlateSwipe/PlateSwipe/compare/fix/edit-ingredient-bug?expand=1))

```kotlin
_fridgeItems.value =
    _fridgeItems.value.filter { it.first != _currentEditingFridgeIngredient.value!!.first }
clearEditingIngredient()
if (quantity != 0)
    updateIngredientFromFridge(ingredient, quantity, expirationDate, scannedItem)
```
The new logic first removes the ingredient being updated from the fridge list and then calls `updateIngredientFromFridge`. This replaces the previous behavior of always adding the ingredient using `addIngredientToUserFridge`. As a result, ingredients with the same expiration date are now correctly merged if their quantity is greater than zero.

### Why was this change made?
This fix improves the functionality of the fridge feature by resolving the merging bug and enhancing the user experience when editing ingredients.

## Checklist
- [x] Tests added.
- [x] Documentation updated.
- [x] All CI checks passed.
- [x] Linked issue/feature: #290
