### PR TITLE
Fix UI inconsistencies in the Create Recipe mode

### DIFF
--- a/app/src/main/java/com/android/sample/resources/C.kt
+++ b/app/src/main/java/com/android/sample/resources/C.kt
@@ -320,7 +320,7 @@ object C {
     val MAXLINES_RECIPE_NAME_FIELD = 2
 
     // RecipeStepScreen
-    val BASE_PADDING = 16.dp
+    val BASE_PADDING = 8.dp
 
     val BUTTON_WIDTH = 200.dp
     val BUTTON_HEIGHT = 50.dp

--- a/app/src/main/java/com/android/sample/ui/createRecipe/PublishRecipeScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/PublishRecipeScreen.kt
@@ -3,7 +3,6 @@ package com.android.sample.ui.createRecipe
 import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -13,20 +12,17 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import com.android.sample.R
 import com.android.sample.model.recipe.CreateRecipeViewModel
 import com.android.sample.model.user.UserViewModel
 import com.android.sample.resources.C.Tag.CHEF_IMAGE_DESCRIPTION
 import com.android.sample.resources.C.Tag.CHEF_IN_EGG_ORIGINAL_RATIO
-import com.android.sample.resources.C.Tag.CORNER_SHAPE_PUBLISH_BUTTON
-import com.android.sample.resources.C.Tag.HORIZONTAL_PADDING
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Route
 import com.android.sample.ui.navigation.Screen
 import com.android.sample.ui.theme.Typography
+import com.android.sample.ui.utils.PlateSwipeButton
 import com.android.sample.ui.utils.PlateSwipeScaffold
 
 @Composable
@@ -81,14 +77,14 @@ fun PublishRecipeContent(
       modifier = modifier,
       horizontalAlignment = Alignment.CenterHorizontally,
       verticalArrangement = Arrangement.SpaceBetween) {
-        Spacer(modifier = Modifier.weight(0.15f))
+        Spacer(modifier = Modifier.weight(1f))
         // Display the done text
         Text(
             text = stringResource(R.string.done_text),
             style = Typography.titleLarge,
-            modifier = Modifier.weight(0.2f).zIndex(1f).testTag("DoneText"),
+            modifier = Modifier.weight(2f).zIndex(1f).testTag("DoneText"),
             color = MaterialTheme.colorScheme.onPrimary)
-        Spacer(modifier = Modifier.weight(0.05f))
+        Spacer(modifier = Modifier.weight(8f))
 
         // Display the chef in egg image
         Image(
@@ -101,8 +97,11 @@ fun PublishRecipeContent(
                     .zIndex(-1f)
                     .testTag("ChefImage"))
 
+        Spacer(modifier = Modifier.weight(6f))
+
         // Display the publish button
-        Button(
+
+        PlateSwipeButton(
             onClick = {
               createRecipeViewModel.publishRecipe(
                   isEditing,
@@ -119,18 +118,9 @@ fun PublishRecipeContent(
                     Toast.makeText(context, exception.message, Toast.LENGTH_SHORT).show()
                   })
             },
-            colors =
-                ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
-            shape = RoundedCornerShape(CORNER_SHAPE_PUBLISH_BUTTON.dp),
-            modifier =
-                Modifier.padding(horizontal = HORIZONTAL_PADDING.dp)
-                    .fillMaxWidth(0.7f)
-                    .weight(0.15f)
-                    .testTag("PublishButton")) {
-              Text(
-                  text = stringResource(R.string.publish_recipe_button),
-                  style = Typography.bodyMedium,
-                  fontWeight = FontWeight.Bold)
-            }
+            modifier = Modifier.testTag("PublishButton"),
+            text = stringResource(R.string.publish_recipe_button))
+
+        Spacer(modifier = Modifier.weight(1f))
       }
 }

--- a/app/src/main/java/com/android/sample/ui/createRecipe/RecipeAddImageScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/RecipeAddImageScreen.kt
@@ -6,7 +6,6 @@ import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -25,7 +24,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.PhotoCamera
-import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -52,8 +50,7 @@ import com.android.sample.feature.camera.openGallery
 import com.android.sample.feature.camera.uriToBitmap
 import com.android.sample.model.recipe.CreateRecipeViewModel
 import com.android.sample.resources.C
-import com.android.sample.resources.C.Tag.RECIPE_NAME_BUTTON_HEIGHT
-import com.android.sample.resources.C.Tag.RECIPE_NAME_BUTTON_WIDTH
+import com.android.sample.resources.C.Dimension.PADDING_8
 import com.android.sample.resources.C.TestTag.RecipeAddImageScreen.BOX_IMAGE
 import com.android.sample.resources.C.TestTag.RecipeAddImageScreen.BOX_NEXT_BUTTON
 import com.android.sample.resources.C.TestTag.RecipeAddImageScreen.CAMERA_BUTTON
@@ -70,7 +67,7 @@ import com.android.sample.resources.C.ZERO
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
 import com.android.sample.ui.theme.Typography
-import com.android.sample.ui.theme.lightCream
+import com.android.sample.ui.utils.PlateSwipeButton
 import com.android.sample.ui.utils.PlateSwipeScaffold
 
 /**
@@ -107,22 +104,24 @@ fun RecipeAddImageContent(
     createRecipeViewModel: CreateRecipeViewModel,
     paddingValues: PaddingValues
 ) {
-  Column(
-      modifier = Modifier.fillMaxSize().padding(paddingValues),
-      verticalArrangement = Arrangement.Center,
-      horizontalAlignment = Alignment.CenterHorizontally) {
-        // Display the progress bar for the recipe creation process
-        RecipeProgressBar(currentStep = C.Tag.ADD_IMAGE_STEP)
+  Box(modifier = Modifier.fillMaxSize().padding(PADDING_8.dp)) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(paddingValues),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally) {
+          // Display the progress bar for the recipe creation process
+          RecipeProgressBar(currentStep = C.Tag.ADD_IMAGE_STEP)
 
-        Spacer(
-            modifier =
-                Modifier.height(
-                    (C.Dimension.RecipeAddImageScreen.SPACER *
-                            LocalConfiguration.current.screenHeightDp)
-                        .dp))
-        // Display the content for adding an image
-        AddImageContent(navigationActions, createRecipeViewModel)
-      }
+          Spacer(
+              modifier =
+                  Modifier.height(
+                      (C.Dimension.RecipeAddImageScreen.SPACER *
+                              LocalConfiguration.current.screenHeightDp)
+                          .dp))
+          // Display the content for adding an image
+          AddImageContent(navigationActions, createRecipeViewModel)
+        }
+  }
 }
 
 /**
@@ -202,7 +201,7 @@ fun AddImageContent(
                                 (C.Dimension.RecipeAddImageScreen.IMAGE *
                                         LocalConfiguration.current.screenHeightDp)
                                     .dp)
-                            .clip(RoundedCornerShape(C.Dimension.PADDING_8.dp))
+                            .clip(RoundedCornerShape(PADDING_8.dp))
                             .testTag(BOX_IMAGE),
                     contentAlignment = Alignment.Center,
                 ) {
@@ -297,26 +296,15 @@ fun AddImageContent(
                       ChefImage()
                     }
                   }
-                  Button(
+                  PlateSwipeButton(
+                      text = stringResource(R.string.next),
+                      modifier = Modifier.testTag("NextStepButton"),
                       onClick = {
                         handleNavigationAndToast(
                             isPictureTaken = isPictureTaken,
                             context = context,
                             navigationActions = navigationActions)
-                      },
-                      modifier =
-                          Modifier.width(RECIPE_NAME_BUTTON_WIDTH)
-                              .height(RECIPE_NAME_BUTTON_HEIGHT)
-                              .background(
-                                  color = lightCream,
-                                  shape = RoundedCornerShape(size = C.Dimension.PADDING_4.dp))
-                              .testTag("NextStepButton"),
-                      shape = RoundedCornerShape(C.Dimension.PADDING_4.dp)) {
-                        Text(
-                            text = stringResource(R.string.next),
-                            style = Typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onPrimary)
-                      }
+                      })
                 }
               }
         }

--- a/app/src/main/java/com/android/sample/ui/createRecipe/RecipeStepScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/RecipeStepScreen.kt
@@ -8,8 +8,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
-import com.android.sample.resources.C.Tag.BASE_PADDING
+import com.android.sample.resources.C.Dimension.PADDING_16
+import com.android.sample.resources.C.Dimension.PADDING_32
+import com.android.sample.resources.C.Dimension.PADDING_8
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Route
 import com.android.sample.ui.utils.PlateSwipeButton
@@ -43,7 +46,7 @@ fun RecipeStepScreen(
       selectedItem = if (isEditing) Route.ACCOUNT else Route.CREATE_RECIPE,
       showBackArrow = true,
       content = { paddingValues ->
-        Box(modifier = modifier.fillMaxSize().padding(paddingValues).padding(BASE_PADDING)) {
+        Box(modifier = modifier.fillMaxSize().padding(paddingValues).padding(PADDING_8.dp)) {
           Column(
               horizontalAlignment = Alignment.CenterHorizontally,
               verticalArrangement = Arrangement.Top,
@@ -58,7 +61,7 @@ fun RecipeStepScreen(
                     text = title,
                     style = MaterialTheme.typography.displayLarge,
                     color = MaterialTheme.colorScheme.onPrimary,
-                    modifier = Modifier.fillMaxWidth().padding(horizontal = BASE_PADDING * 2),
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = PADDING_16.dp),
                     textAlign = TextAlign.Center)
 
                 Spacer(modifier = Modifier.weight(0.05f))
@@ -68,7 +71,7 @@ fun RecipeStepScreen(
                     text = subtitle,
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onPrimary,
-                    modifier = Modifier.padding(horizontal = BASE_PADDING * 2).zIndex(1f),
+                    modifier = Modifier.padding(horizontal = PADDING_32.dp).zIndex(1f),
                     textAlign = TextAlign.Center)
 
                 Spacer(modifier = Modifier.weight(0.05f))

--- a/app/src/main/java/com/android/sample/ui/createRecipe/TimePickerScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/createRecipe/TimePickerScreen.kt
@@ -27,6 +27,7 @@ import com.android.sample.R
 import com.android.sample.model.recipe.CreateRecipeViewModel
 import com.android.sample.resources.C.Dimension.PADDING_16
 import com.android.sample.resources.C.Dimension.PADDING_32
+import com.android.sample.resources.C.Dimension.PADDING_8
 import com.android.sample.resources.C.Tag.HOUR_RANGE_END
 import com.android.sample.resources.C.Tag.HOUR_RANGE_START
 import com.android.sample.resources.C.Tag.MINUTES_PER_HOUR
@@ -90,7 +91,7 @@ fun TimePickerContent(
   val hours = remember { mutableIntStateOf(initialHours) }
   val minutes = remember { mutableIntStateOf(initialMinutes) }
 
-  Box(modifier = modifier.padding(PADDING_16.dp), contentAlignment = Alignment.TopCenter) {
+  Box(modifier = modifier.padding(PADDING_8.dp), contentAlignment = Alignment.TopCenter) {
     Column(
         modifier = Modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -107,7 +108,7 @@ fun TimePickerContent(
               color = MaterialTheme.colorScheme.onPrimary,
               modifier =
                   Modifier.fillMaxWidth()
-                      .padding(horizontal = PADDING_32.dp)
+                      .padding(horizontal = PADDING_16.dp)
                       .testTag(TIME_PICKER_TITLE),
               textAlign = TextAlign.Center)
 


### PR DESCRIPTION

# Description

## **What has been changed?**  
   - **PublishRecipeScreen**:  
     - Adjusted button size and thickness.  
     - Replaced the button with the `PlateSwipeButton` from utils to ensure consistency.  
     - Updated layout disposition using weight to share space properly and improve visual balance.  
   - **RecipeAddImageScreen**:  
     - Updated padding to maintain consistency across the Create Recipe screens.  
     - Fixed the shifted `RecipeStepProgressBar` alignment compared to other screens.  
   - **RecipeStepScreen**:  
     - Standardized padding for elements to align with other screens in the Create Recipe flow.  
   - **TimerPickerScreen**:  
     - Updated padding to ensure consistency with the rest of the Create Recipe screens.  

## **Why was this change made?**  
   - These changes address UI inconsistencies identified in user feedback. The goal is to improve visual consistency, alignment, and spacing across most of the screens in the Create Recipe flow, leading to a better user experience.

# Checklist
- [x] Tests added.  
- [x] Documentation updated.  
- [x] All CI checks passed.  
- [x] Linked issue/feature: #296 

